### PR TITLE
ci: build, tag and push to registry

### DIFF
--- a/.github/workflows/deploy_aws.yml
+++ b/.github/workflows/deploy_aws.yml
@@ -47,48 +47,21 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
-    - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+    - name: Login to Docker Hub
+      uses: docker/login-action@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ env.AWS_REGION }}
-
-    - name: Login to Amazon ECR
-      id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1.6.2
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
     - name: Build, tag, and push image to Amazon ECR
       id: build-image
       env:
-        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        DOCKER_HUB_USERNAME : ${{ secrets.DOCKER_HUB_USERNAME }}
+        DOCKER_HUB_REPOSITORY : "fs-service"
         IMAGE_TAG: ${{ github.sha }}
       run: |
         echo ${{ matrix.folders }} 
         cd ${{ matrix.folders }}
-        docker build -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG .
-        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
-        echo "image=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT
-
-    - name: download the service task definition file
-      id: download-task-definition
-      run: |
-          aws ecs describe-task-definition --task-definition ${{ env.ECS_TASK_DEFINITION }} \
-          --query taskDefinition > task-definition.json
-
-    - name: Fill in the new image ID in the Amazon ECS task definition
-      id: task-def
-      uses: aws-actions/amazon-ecs-render-task-definition@v1
-      with:
-        task-definition: task-definition.json
-        container-name: ${{ matrix.folders }}
-        image: ${{ steps.build-image.outputs.image }}
-
-    - name: Deploy to Amazon ECS
-      id: deploy-to-ecs
-      uses: aws-actions/amazon-ecs-deploy-task-definition@v1
-      with:
-        task-definition: ${{ steps.task-def.outputs.task-definition }}
-        service: ${{ env.ECS_SERVICE }}
-        cluster: ${{ env.ECS_CLUSTER }}
-        wait-for-service-stability: true
+        docker build -t $DOCKER_HUB_USERNAME/$DOCKER_HUB_REPOSITORY:${{ matrix.folders }}_$IMAGE_TAG .
+        docker push $DOCKER_HUB_USERNAME/$DOCKER_HUB_REPOSITORY:$IMAGE_TAG
+        echo "image=$DOCKER_HUB_USERNAME/$DOCKER_HUB_REPOSITORY:$IMAGE_TAG" >> $GITHUB_OUTPUT

--- a/docs/15012024.md
+++ b/docs/15012024.md
@@ -1,0 +1,59 @@
+# January 15th
+## 2023 Recap
+1. Basic Structure.
+2. How to handle Errors:
+	1. Logs.
+	2. Alerts and Monitoring.
+	3. Circuit braker
+	4. Gracefull degradations
+	5. timeouts and retries.
+3. CI - Using Docker and Github Actions
+4. CD - Using Docker, Docker Registry and Github Actions.
+
+
+## Continuous Deployment:
+1. Build an Image from a Merge for a Pull request
+2. Push an Image to a registry (Use Docker hub)
+3. Login via SSH to a EC2 Instance
+4. Run the Docker instance with the new version.
+
+
+### 1. Build an Image from a Merge for a Pull Request
+
+**Assumption**: You have a GitHub repository and a Docker hub repository with your application code and a Dockerfile.
+
+**Step-by-Step**:
+1. **Merge the Pull Request**: First, merge the pull request into your main branch.
+
+2. **Clone the Repository**:
+   ```bash
+   git clone https://github.com/your-username/your-repo.git
+   cd your-repo
+   ```
+
+3. **Build the Docker Image**:
+   - Ensure you have a Dockerfile in the root of your repository.
+   - Build the image with a tag:
+     ```bash
+     docker build -t your-username/your-app:latest .
+     ```
+
+### 2. Push an Image to a Registry (Docker Hub)
+
+**Prerequisites**: Docker Hub account and Docker installed on your machine.
+
+**Step-by-Step**:
+1. **Log in to Docker Hub**:
+   ```bash
+   docker login
+   ```
+
+2. **Tag Your Image** (if not already done):
+   ```bash
+   docker tag your-app:latest your-username/your-app:latest
+   ```
+
+3. **Push the Image to Docker Hub**:
+   ```bash
+   docker push your-username/your-app:latest
+   ```


### PR DESCRIPTION
Create a simplified version of the workflow where image is push to a public repository.


Lab, part 1: publish your builded images to a public server.

Lab, part 2: automate to run the latest image version in a EC2 instant

```

   - name: Deploy to AWS EC2
      uses: appleboy/ssh-action@master
      with:
        host: your-ec2-instance-public-ip
        username: ec2-user
        key: ${{ secrets.SSH_PRIVATE_KEY }}
        script: |
          docker pull ${{ secrets.DOCKER_HUB_USERNAME }}/your-app:latest
          docker stop web || true
          docker run -d --name web -p 80:80 ${{ secrets.DOCKER_HUB_USERNAME }}/your-app:latest
```
