### PR TITLE
feat: add dummy implementation of feature flagging using in memory flags

### DIFF
--- a/flight_scrapper_service/conf.ini
+++ b/flight_scrapper_service/conf.ini
@@ -1,9 +1,9 @@
 [Default]
-repository=redis
-publisher=redis
+repository=memory
+publisher=memory
 publish_channel=search-params
 publish_mode=publish
-airline=google
+airline=dummy
 scrapper_driver=firefox
 
 [Scrappers.Avianca]

--- a/flight_scrapper_service/infrastructure/feature_flag/flags.py
+++ b/flight_scrapper_service/infrastructure/feature_flag/flags.py
@@ -1,0 +1,10 @@
+from openfeature import api
+from openfeature.provider.in_memory_provider import InMemoryProvider
+
+from infrastructure.feature_flag.memory_provider import WELCOME_MESSAGE_FLAG, my_flags
+
+api.set_provider(InMemoryProvider(my_flags))
+
+feature_flag_client = api.get_client()
+
+flag_value = feature_flag_client.get_boolean_value(WELCOME_MESSAGE_FLAG, False)

--- a/flight_scrapper_service/infrastructure/feature_flag/memory_provider.py
+++ b/flight_scrapper_service/infrastructure/feature_flag/memory_provider.py
@@ -1,0 +1,10 @@
+from openfeature.provider.in_memory_provider import InMemoryFlag
+
+#Flags
+WELCOME_MESSAGE_FLAG = "welcome message on"
+
+
+#Flags definition
+my_flags = {
+  WELCOME_MESSAGE_FLAG: InMemoryFlag("off", {"on": True, "off": False})
+}

--- a/flight_scrapper_service/infrastructure/scrappers/dummy/scrapper.py
+++ b/flight_scrapper_service/infrastructure/scrappers/dummy/scrapper.py
@@ -13,7 +13,7 @@ class DummyScrapper(Scrapper):
 
     def __init__(
         self,
-        create_driver: Callable[[str, dict, Union[str, None]], Any]
+        create_driver: Callable[[str, dict, Union[str, None]], Any],
     ) -> None:
         self.create_driver = create_driver
 

--- a/flight_scrapper_service/presentations/rest/main.py
+++ b/flight_scrapper_service/presentations/rest/main.py
@@ -6,6 +6,8 @@ from pydantic import ValidationError
 
 from constants import config
 from domain.models import SearchParams
+from infrastructure.feature_flag.flags import feature_flag_client
+from infrastructure.feature_flag.memory_provider import WELCOME_MESSAGE_FLAG
 from main import dependencies
 from presentations.rest.models.inputs import Inputs, SearchParamsInputModel
 
@@ -57,7 +59,8 @@ def create_app():
 
     @app.route("/")
     def hello_world():
-        return {"status": "alive", "timestamp": datetime.now()}
+        is_message_on = feature_flag_client.get_boolean_value(WELCOME_MESSAGE_FLAG, False)
+        return {"status": "alive" if is_message_on else "running", "timestamp": datetime.now()}
 
     return app
 

--- a/flight_scrapper_service/requirements.txt
+++ b/flight_scrapper_service/requirements.txt
@@ -61,3 +61,6 @@ confluent_kafka
 
 #faker
 faker
+
+#openfeature
+openfeature-sdk==0.8.1


### PR DESCRIPTION
Add a dummy implementation of feature flags. you can find the flags definition in `flight_scrapper_service/infrastructure/feature_flag/flags.py`


You can test it by running the Docker file

```
docker compose up flight-scrapper --build 
```

and executing the curl call
```
curl 'http://localhost:8001/'
```

