### PR TITLE
feat: add status update functionality to UpdateTripUseCase and Unauth…

### DIFF
--- a/auth_service/routes.yml
+++ b/auth_service/routes.yml
@@ -10,6 +10,7 @@ vacation-planner:
   available_routes:
     - /api/trips
     - /api/trips/*
+    - /api/trips/*/*
     - /api/trips/*/flights/*/status
     - /api/trips/*/accommodations/*/status
     - /api/trips/*/activities/*/status

--- a/fe-client/src/Models.ts
+++ b/fe-client/src/Models.ts
@@ -4,7 +4,7 @@ export interface Trip {
     destination: string;
     startDate: Date;
     endDate: Date;
-    status: 'planning' | 'confirmed' | 'completed';
+    status: 'planning' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
     travelers: Traveler[];
     flights: Flight[];
     accommodations: Accommodation[];

--- a/fe-client/src/components/TripPlansList.jsx
+++ b/fe-client/src/components/TripPlansList.jsx
@@ -31,9 +31,13 @@ const TripPlansList = () => {
             case 'confirmed':
                 return 'bg-green-100 text-green-800 border-green-200';
             case 'planning':
-                return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+                return 'bg-blue-100 text-blue-800 border-blue-200';
+            case 'in_progress':
+                return 'bg-amber-100 text-amber-800 border-amber-200';
             case 'completed':
                 return 'bg-gray-100 text-gray-800 border-gray-200';
+            case 'cancelled':
+                return 'bg-red-100 text-red-800 border-red-200';
             default:
                 return 'bg-gray-100 text-gray-800 border-gray-200';
         }

--- a/fe-client/src/services/TripService.ts
+++ b/fe-client/src/services/TripService.ts
@@ -16,6 +16,8 @@ export interface ITripService {
 
     updateTrip(id: string, updates: Partial<Trip>): Promise<Trip>;
 
+    updateTripStatus(id: string, status: string): Promise<Trip>;
+
     deleteTrip(id: string): Promise<boolean>;
 
     updateFlightStatus(tripId: string, flightId: string, status: string): Promise<Trip>;
@@ -108,6 +110,30 @@ class SimpleTripService implements ITripService {
         this.trips[index] = updatedTrip;
 
         console.log('✅ Trip updated:', updatedTrip);
+
+        return updatedTrip;
+    }
+
+    /**
+     * Update trip status
+     */
+    async updateTripStatus(id: string, status: string): Promise<Trip> {
+        await this.delay(200);
+
+        const index = this.trips.findIndex(t => t.id === id);
+        if (index === -1) {
+            throw new Error(`Trip with id ${id} not found`);
+        }
+
+        // Update status
+        const updatedTrip = {
+            ...this.trips[index],
+            status: status as Trip['status'],
+        };
+
+        this.trips[index] = updatedTrip;
+
+        console.log('✅ Trip status updated:', updatedTrip);
 
         return updatedTrip;
     }
@@ -227,6 +253,17 @@ class ApiTripService implements ITripService {
             body: JSON.stringify(updates),
         });
         if (!response.ok) throw new Error('Failed to update trip');
+        return response.json();
+    }
+
+    async updateTripStatus(id: string, status: string): Promise<Trip> {
+        const response = await fetch(`${this.baseUrl}/${id}/status`, {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status }),
+        });
+        if (!response.ok) throw new Error('Failed to update trip status');
         return response.json();
     }
 

--- a/fe-client/src/tripDetailsView.tsx
+++ b/fe-client/src/tripDetailsView.tsx
@@ -13,6 +13,7 @@ import { tripService } from "./services/TripService.ts";
 import { ChildType } from "./config/childStatusTransitions.ts";
 
 type TabKey = 'overview' | 'flights' | 'stays' | 'activities' | 'budget' | 'team';
+type TripStatus = 'planning' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
 
 interface Tab {
     key: TabKey;
@@ -61,6 +62,9 @@ const TripDetailsView = () => {
     const [trip, setTrip] = useState<Trip | null>(null);
     const [activeTab, setActiveTab] = useState<TabKey>('overview');
     const [toast, setToast] = useState<Toast | null>(null);
+    const [originalStatus, setOriginalStatus] = useState<TripStatus | null>(null);
+    const [isUpdating, setIsUpdating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const navigate = useNavigate();
 
     /**
@@ -108,7 +112,11 @@ const TripDetailsView = () => {
     useEffect(() => {
         const timer = setTimeout(async () => {
             if (tripId) {
-                setTrip(await tripService.getTripById(tripId));
+                const fetchedTrip = await tripService.getTripById(tripId);
+                if (fetchedTrip) {
+                    setTrip(fetchedTrip);
+                    setOriginalStatus(fetchedTrip.status);
+                }
             }
         }, 500);
 
@@ -121,6 +129,26 @@ const TripDetailsView = () => {
         const timer = setTimeout(() => setToast(null), 4000);
         return () => clearTimeout(timer);
     }, [toast]);
+
+    const handleStatusChange = async (newStatus: TripStatus) => {
+        if (!trip || !tripId) return;
+
+        setIsUpdating(true);
+        setError(null);
+
+        try {
+            const updatedTrip = await tripService.updateTripStatus(tripId, newStatus);
+            setTrip(updatedTrip);
+            setOriginalStatus(updatedTrip.status);
+        } catch (err) {
+            setError('Failed to update status');
+            if (trip) {
+                setTrip({ ...trip, status: originalStatus || trip.status });
+            }
+        } finally {
+            setIsUpdating(false);
+        }
+    };
 
     const renderTabContent = () => {
         if (!trip) return null;
@@ -227,6 +255,28 @@ const TripDetailsView = () => {
                                     className={`inline-block px-3 py-1 rounded-full text-sm font-medium capitalize ${getStatusColor(trip.status)}`}>
                                     {trip.status}
                                 </span>
+                                <select
+                                    value={trip.status}
+                                    onChange={(e) => handleStatusChange(e.target.value as TripStatus)}
+                                    disabled={isUpdating}
+                                    className={`px-3 py-1 rounded-lg text-sm font-medium border ${
+                                        isUpdating
+                                            ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
+                                            : 'bg-white text-gray-700 border-gray-300 cursor-pointer hover:border-gray-400'
+                                    }`}
+                                >
+                                    <option value="planning">Planning</option>
+                                    <option value="confirmed">Confirmed</option>
+                                    <option value="in_progress">In Progress</option>
+                                    <option value="completed">Completed</option>
+                                    <option value="cancelled">Cancelled</option>
+                                </select>
+                                {isUpdating && (
+                                    <span className="text-sm text-gray-500">Updating...</span>
+                                )}
+                                {error && (
+                                    <span className="text-sm text-red-600">{error}</span>
+                                )}
                             </div>
 
                             {/* Location */}

--- a/fe-client/src/tripDetailsView.tsx
+++ b/fe-client/src/tripDetailsView.tsx
@@ -248,21 +248,17 @@ const TripDetailsView = () => {
                 <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
                     <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
                         <div className="flex-1">
-                            {/* Title and Status Badge */}
+                            {/* Title and Status Badge (Clickable Dropdown) */}
                             <div className="flex items-center gap-3 mb-3">
                                 <h1 className="text-3xl font-bold text-gray-900">{trip.name}</h1>
-                                <span
-                                    className={`inline-block px-3 py-1 rounded-full text-sm font-medium capitalize ${getStatusColor(trip.status)}`}>
-                                    {trip.status}
-                                </span>
                                 <select
                                     value={trip.status}
                                     onChange={(e) => handleStatusChange(e.target.value as TripStatus)}
                                     disabled={isUpdating}
-                                    className={`px-3 py-1 rounded-lg text-sm font-medium border ${
+                                    className={`px-3 py-1 rounded-full text-sm font-medium capitalize border-2 ${
                                         isUpdating
-                                            ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
-                                            : 'bg-white text-gray-700 border-gray-300 cursor-pointer hover:border-gray-400'
+                                            ? `opacity-50 cursor-not-allowed ${getStatusColor(trip.status)}`
+                                            : `${getStatusColor(trip.status)} cursor-pointer hover:opacity-80`
                                     }`}
                                 >
                                     <option value="planning">Planning</option>
@@ -275,7 +271,7 @@ const TripDetailsView = () => {
                                     <span className="text-sm text-gray-500">Updating...</span>
                                 )}
                                 {error && (
-                                    <span className="text-sm text-red-600">{error}</span>
+                                    <span className="text-sm text-red-600 ml-2">{error}</span>
                                 )}
                             </div>
 

--- a/fe-client/src/utils/StatusColors.ts
+++ b/fe-client/src/utils/StatusColors.ts
@@ -1,9 +1,16 @@
 export const getStatusColor = (status: string): string => {
     const statusLower = status.toLowerCase();
+    // Trip status colors
+    if (statusLower === 'planning') return 'bg-blue-100 text-blue-700';
+    if (statusLower === 'in_progress') return 'bg-amber-100 text-amber-700';
+    if (statusLower === 'completed') return 'bg-gray-100 text-gray-700';
+
     // PRD-07 FR-10: pending → gray, confirmed/booked → green, cancelled → red
     if (statusLower === 'confirmed') return 'bg-green-100 text-green-700';
     if (statusLower === 'booked') return 'bg-green-100 text-green-700';
     if (statusLower === 'pending') return 'bg-gray-100 text-gray-700';
     if (statusLower === 'cancelled') return 'bg-red-100 text-red-700';
+
+    // Default fallback
     return 'bg-gray-100 text-gray-700';
 };

--- a/vacation_stay_scrapper/src/shared/domain/exceptions.py
+++ b/vacation_stay_scrapper/src/shared/domain/exceptions.py
@@ -70,3 +70,15 @@ class InvalidStatusTransition(ValidationError):
     descriptive message is surfaced to the client in the response details.
     """
     pass
+
+
+class UnauthorizedAccess(DomainException):
+    """Raised when a user attempts to access a resource they don't own"""
+
+    def __init__(self, resource_type: str, resource_id: str, user_id: str):
+        self.resource_type = resource_type
+        self.resource_id = resource_id
+        self.user_id = user_id
+        super().__init__(
+            f"User '{user_id}' is not authorized to access {resource_type} '{resource_id}'"
+        )

--- a/vacation_stay_scrapper/src/shared/presentation/middleware.py
+++ b/vacation_stay_scrapper/src/shared/presentation/middleware.py
@@ -15,7 +15,8 @@ from src.shared.domain.exceptions import (
     EntityNotFound,
     ValidationError,
     BusinessRuleViolation,
-    ServiceUnavailable
+    ServiceUnavailable,
+    UnauthorizedAccess
 )
 
 logger = setup_logger(__name__)
@@ -131,7 +132,23 @@ def setup_exception_handlers(app: FastAPI):
                 "details": str(exc)
             }
         )
-    
+
+    @app.exception_handler(UnauthorizedAccess)
+    async def unauthorized_access_handler(
+        request: Request,
+        exc: UnauthorizedAccess
+    ):
+        logger.warning(f"Unauthorized access: {exc}")
+        return JSONResponse(
+            status_code=status.HTTP_403_FORBIDDEN,
+            content={
+                "message": str(exc),
+                "resource_type": exc.resource_type,
+                "resource_id": exc.resource_id,
+                "user_id": exc.user_id
+            }
+        )
+
     @app.exception_handler(DomainException)
     async def domain_exception_handler(
         request: Request,

--- a/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
+++ b/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
@@ -1,8 +1,9 @@
+from datetime import date
+
 from ...domain.entities.trip import Trip
 from ...domain.repositories.trip_repository import ITripRepository
 from ...domain.value_objects.trip_status import TripStatus
 from ....shared.domain.exceptions import EntityNotFound
-from datetime import date
 
 
 class UpdateTripUseCase:
@@ -41,8 +42,8 @@ class UpdateTripUseCase:
         Update the status of a trip owned by the authenticated user.
 
         Verifies the trip exists and belongs to the given owner before
-        applying the status update. Both "not found" and "wrong owner" raise
-        EntityNotFound to avoid leaking trip existence to other users.
+        applying the status update. Uses the repository's update_status method
+        to avoid SQLAlchemy identity map conflicts.
 
         Args:
             trip_id: Trip identifier string
@@ -61,7 +62,12 @@ class UpdateTripUseCase:
         if trip is None:
             raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
 
+        updated = await self._repository.update_status(trip_id_int, str(new_status))
+
+        if not updated:
+            raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
+
         trip.status = new_status
         trip.updated_at = date.today()
 
-        return await self._repository.save(trip)
+        return trip

--- a/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
+++ b/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
@@ -1,23 +1,12 @@
-"""
-Update Trip Use Case
-
-Handles trip updates.
-"""
 from ...domain.entities.trip import Trip
 from ...domain.repositories.trip_repository import ITripRepository
+from ...domain.value_objects.trip_status import TripStatus
 from ....shared.domain.exceptions import EntityNotFound
+from datetime import date
 
 
 class UpdateTripUseCase:
-    """Use case for updating an existing trip"""
-
     def __init__(self, repository: ITripRepository):
-        """
-        Initialize use case
-
-        Args:
-            repository: Trip repository implementation
-        """
         self._repository = repository
 
     async def execute(self, trip_id: str, updated_trip: Trip, owner_id: str) -> Trip:
@@ -46,3 +35,33 @@ class UpdateTripUseCase:
             raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
 
         return await self._repository.save(updated_trip)
+
+    async def update_status(self, trip_id: str, owner_id: str, new_status: TripStatus) -> Trip:
+        """
+        Update the status of a trip owned by the authenticated user.
+
+        Verifies the trip exists and belongs to the given owner before
+        applying the status update. Both "not found" and "wrong owner" raise
+        EntityNotFound to avoid leaking trip existence to other users.
+
+        Args:
+            trip_id: Trip identifier string
+            owner_id: Authenticated user ID (JWT sub claim)
+            new_status: New status to apply to the trip
+
+        Returns:
+            Updated trip
+
+        Raises:
+            EntityNotFound: If trip doesn't exist or is not owned by the user
+        """
+        trip_id_int = int(trip_id)
+
+        trip = await self._repository.find_by_owner(trip_id_int, owner_id)
+        if trip is None:
+            raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
+
+        trip.status = new_status
+        trip.updated_at = date.today()
+
+        return await self._repository.save(trip)

--- a/vacation_stay_scrapper/src/trips/domain/repositories/trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/domain/repositories/trip_repository.py
@@ -87,11 +87,25 @@ class ITripRepository(ABC):
     async def exists(self, trip_id: int) -> bool:
         """
         Check if trip exists
-        
+
         Args:
             trip_id: Trip identifier
-            
+
         Returns:
             True if exists, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        """
+        Update the status of a trip
+
+        Args:
+            trip_id: Trip identifier
+            status: New status value
+
+        Returns:
+            True if updated, False if not found
         """
         pass

--- a/vacation_stay_scrapper/src/trips/infrastructure/persistence/in_memory_trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/infrastructure/persistence/in_memory_trip_repository.py
@@ -112,6 +112,24 @@ class InMemoryTripRepository(ITripRepository):
             True if exists, False otherwise
         """
         return trip_id in self._storage
+
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        """
+        Update the status of a trip
+
+        Args:
+            trip_id: Trip integer identifier
+            status: New status value
+
+        Returns:
+            True if updated, False if not found
+        """
+        trip = self._storage.get(trip_id)
+        if trip is None:
+            return False
+        trip.status = status
+        trip.updated_at = date.today()
+        return True
     
     def count(self) -> int:
         """Get total number of trips"""

--- a/vacation_stay_scrapper/src/trips/infrastructure/persistence/postgres_trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/infrastructure/persistence/postgres_trip_repository.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import List, Optional
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.trips.domain.entities.trip import Trip
@@ -73,3 +73,12 @@ class PostgresTripRepository(ITripRepository):
             select(TripOrm.id_).where(TripOrm.id_ == trip_id)
         )
         return result.scalar_one_or_none() is not None
+
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        result = await self._session.execute(
+            update(TripOrm)
+            .where(TripOrm.id_ == trip_id)
+            .values(status=status, updated_at=date.today())
+        )
+        await self._session.flush()
+        return result.rowcount > 0

--- a/vacation_stay_scrapper/src/trips/presentation/api/routes.py
+++ b/vacation_stay_scrapper/src/trips/presentation/api/routes.py
@@ -5,15 +5,17 @@ FastAPI routes for trip management CRUD operations.
 """
 import logging
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, status, HTTPException
 from typing import List, Annotated
 
 from fastapi.security import HTTPBearer
 
 from src.shared.infrastructure.auth.dependencies import get_current_user
+from src.shared.domain.exceptions import EntityNotFound
 from .schemas import (
     TripCreateRequest,
     TripUpdateRequest,
+    UpdateTripStatusRequest,
     TripResponse,
     TripListResponse,
     MessageResponse,
@@ -36,6 +38,7 @@ from ...application.use_cases.delete_trip import DeleteTripUseCase
 from ...application.use_cases.update_flight_status import UpdateFlightStatusUseCase
 from ...application.use_cases.update_accommodation_status import UpdateAccommodationStatusUseCase
 from ...application.use_cases.update_activity_status import UpdateActivityStatusUseCase
+from ...domain.value_objects.trip_status import TripStatus
 from ..mappers.trip_mapper import TripMapper
 
 # Create router
@@ -263,3 +266,42 @@ async def delete_trip(
     return MessageResponse(
         message=f"Trip {trip_id} deleted successfully"
     )
+
+
+@router.patch(
+    "/{trip_id}/status",
+    response_model=TripResponse,
+    summary="Update trip status"
+)
+async def update_trip_status(
+        trip_id: str,
+        request: UpdateTripStatusRequest,
+        use_case: UpdateTripUseCase = Depends(get_update_trip_use_case),
+        current_user: dict = Depends(get_current_user)
+) -> TripResponse:
+    """
+    Update the status of a trip. Only the owner can update their trip's status.
+
+    Args:
+        trip_id: Trip identifier
+        request: Update trip status request
+        use_case: Update trip use case (injected)
+        current_user: Decoded JWT claims from the authenticated user
+
+    Returns:
+        Updated trip details
+
+    Raises:
+        HTTPException: 404 if trip not found or not owned by user
+    """
+    owner_id = current_user["sub"]
+
+    try:
+        new_status = TripStatus.from_string(request.status)
+        updated_trip = await use_case.update_status(trip_id, owner_id, new_status)
+        return TripMapper.to_response(updated_trip)
+    except EntityNotFound as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e)
+        )

--- a/vacation_stay_scrapper/src/trips/presentation/api/schemas.py
+++ b/vacation_stay_scrapper/src/trips/presentation/api/schemas.py
@@ -8,6 +8,8 @@ from pydantic import BaseModel, Field
 from datetime import date, datetime
 from typing import List, Optional, Literal
 
+TripStatusType = Literal["planning", "confirmed", "in_progress", "completed", "cancelled"]
+
 
 # ============================================================================
 # REQUEST SCHEMAS FOR NESTED OBJECTS
@@ -181,13 +183,13 @@ class TripResponse(BaseModel):
     destination: str
     start_date: date = Field(alias="startDate")
     end_date: date = Field(alias="endDate")
-    status: Literal["planning", "confirmed", "completed"]
+    status: TripStatusType
     travelers: List[TravelerResponse] = []
     flights: List[FlightResponse] = []
     accommodations: List[AccommodationResponse] = []
     activities: List[ActivityResponse] = []
     budget: BudgetResponse
-    
+
     class Config:
         populate_by_name = True
 
@@ -199,7 +201,7 @@ class TripResponse(BaseModel):
 class TripCreateRequest(BaseModel):
     """
     Request schema for creating a trip with all nested objects
-    
+
     Now supports creating a complete trip with flights, accommodations,
     activities, and travelers in a single request.
     """
@@ -208,15 +210,15 @@ class TripCreateRequest(BaseModel):
     destination: str = Field(..., min_length=1, max_length=200)
     start_date: date = Field(alias="startDate")
     end_date: date = Field(alias="endDate")
-    status: Optional[Literal["planning", "confirmed", "completed"]] = "planning"
-    
+    status: Optional[TripStatusType] = "planning"
+
     # Nested objects (optional, defaults to empty lists)
     travelers: Optional[List[TravelerCreateRequest]] = Field(default_factory=list)
     flights: Optional[List[FlightCreateRequest]] = Field(default_factory=list)
     accommodations: Optional[List[AccommodationCreateRequest]] = Field(default_factory=list)
     activities: Optional[List[ActivityCreateRequest]] = Field(default_factory=list)
     budget: Optional[BudgetRequest] = None
-    
+
     class Config:
         populate_by_name = True
 
@@ -240,15 +242,23 @@ class TripUpdateRequest(BaseModel):
     destination: Optional[str] = None
     start_date: Optional[date] = Field(None, alias="startDate")
     end_date: Optional[date] = Field(None, alias="endDate")
-    status: Optional[Literal["planning", "confirmed", "completed"]] = None
-    
+    status: Optional[TripStatusType] = None
+
     # Nested objects for update (optional)
     travelers: Optional[List[TravelerCreateRequest]] = None
     flights: Optional[List[FlightCreateRequest]] = None
     accommodations: Optional[List[AccommodationCreateRequest]] = None
     activities: Optional[List[ActivityCreateRequest]] = None
     budget: Optional[BudgetRequest] = None
-    
+
+    class Config:
+        populate_by_name = True
+
+
+class UpdateTripStatusRequest(BaseModel):
+    """Request schema for updating a trip's status"""
+    status: TripStatusType = Field(..., description="New status for the trip")
+
     class Config:
         populate_by_name = True
 

--- a/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
+++ b/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
@@ -1,0 +1,154 @@
+"""
+Unit tests for UpdateTripUseCase.update_status.
+"""
+import asyncio
+from datetime import date
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.shared.domain.exceptions import EntityNotFound
+from src.trips.application.use_cases.update_trip import UpdateTripUseCase
+from src.trips.domain.entities.trip import Trip
+from src.trips.domain.value_objects.trip_status import TripStatus
+
+
+def make_trip(trip_id: int = 1, owner_id: str = "user-1", status: TripStatus = TripStatus.PLANNING) -> Trip:
+    """Return a minimal valid Trip for use in tests."""
+    return Trip(
+        id=trip_id,
+        owner_id=owner_id,
+        name="Summer Holiday",
+        destination="Barcelona",
+        start_date=date(2025, 7, 1),
+        end_date=date(2025, 7, 8),
+        status=status,
+    )
+
+
+def make_repo(**method_returns) -> AsyncMock:
+    """
+    Return a mock repository.
+
+    Pass keyword arguments matching repository method names to control
+    what each method returns, e.g. make_repo(save=trip, find_by_id=trip).
+    """
+    repo = AsyncMock()
+    for method, return_value in method_returns.items():
+        getattr(repo, method).return_value = return_value
+    return repo
+
+
+class TestUpdateTripUseCaseStatus:
+
+    def test_returns_updated_trip_with_new_status(self):
+        trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        result = asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
+        )
+
+        assert result.status == TripStatus.CONFIRMED
+        assert result.updated_at is not None
+
+    def test_calls_save_on_repository(self):
+        trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
+        )
+
+        repo.save.assert_called_once()
+
+    def test_raises_entity_not_found_when_trip_is_missing(self):
+        repo = make_repo(find_by_owner=None)
+
+        with pytest.raises(EntityNotFound) as exc_info:
+            asyncio.run(
+                UpdateTripUseCase(repo).update_status("999", "user-1", TripStatus.CONFIRMED)
+            )
+
+        assert exc_info.value.entity_type == "Trip"
+        assert exc_info.value.entity_id == "999"
+
+    def test_raises_entity_not_found_when_trip_is_not_owned_by_user(self):
+        repo = make_repo(find_by_owner=None)
+
+        with pytest.raises(EntityNotFound):
+            asyncio.run(
+                UpdateTripUseCase(repo).update_status("42", "different-user", TripStatus.CONFIRMED)
+            )
+
+    def test_does_not_call_save_when_trip_does_not_exist(self):
+        repo = make_repo(find_by_owner=None)
+
+        with pytest.raises(EntityNotFound):
+            asyncio.run(
+                UpdateTripUseCase(repo).update_status("999", "user-1", TripStatus.CONFIRMED)
+            )
+
+        repo.save.assert_not_called()
+
+    def test_transitions_to_in_progress_status(self):
+        trip = make_trip(trip_id=1, status=TripStatus.CONFIRMED)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        result = asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.IN_PROGRESS)
+        )
+
+        assert result.status == TripStatus.IN_PROGRESS
+
+    def test_transitions_to_completed_status(self):
+        trip = make_trip(trip_id=1, status=TripStatus.IN_PROGRESS)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        result = asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.COMPLETED)
+        )
+
+        assert result.status == TripStatus.COMPLETED
+
+    def test_transitions_to_cancelled_status(self):
+        trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        result = asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CANCELLED)
+        )
+
+        assert result.status == TripStatus.CANCELLED
+
+    def test_transitions_back_to_planning_status(self):
+        trip = make_trip(trip_id=1, status=TripStatus.CANCELLED)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        result = asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.PLANNING)
+        )
+
+        assert result.status == TripStatus.PLANNING
+
+    def test_passes_correct_trip_id_to_repository(self):
+        trip = make_trip(trip_id=1)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
+        )
+
+        called_with = repo.find_by_owner.call_args[0][0]
+        assert called_with == 1
+
+    def test_passes_correct_owner_id_to_repository(self):
+        trip = make_trip(trip_id=1)
+        repo = make_repo(find_by_owner=trip, save=trip)
+
+        asyncio.run(
+            UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
+        )
+
+        called_with = repo.find_by_owner.call_args[0][1]
+        assert called_with == "user-1"

--- a/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
+++ b/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
@@ -43,7 +43,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_returns_updated_trip_with_new_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
@@ -52,15 +52,15 @@ class TestUpdateTripUseCaseStatus:
         assert result.status == TripStatus.CONFIRMED
         assert result.updated_at is not None
 
-    def test_calls_save_on_repository(self):
+    def test_calls_update_status_on_repository(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
         )
 
-        repo.save.assert_called_once()
+        repo.update_status.assert_called_once()
 
     def test_raises_entity_not_found_when_trip_is_missing(self):
         repo = make_repo(find_by_owner=None)
@@ -81,7 +81,7 @@ class TestUpdateTripUseCaseStatus:
                 UpdateTripUseCase(repo).update_status("42", "different-user", TripStatus.CONFIRMED)
             )
 
-    def test_does_not_call_save_when_trip_does_not_exist(self):
+    def test_does_not_call_update_status_when_trip_does_not_exist(self):
         repo = make_repo(find_by_owner=None)
 
         with pytest.raises(EntityNotFound):
@@ -89,11 +89,11 @@ class TestUpdateTripUseCaseStatus:
                 UpdateTripUseCase(repo).update_status("999", "user-1", TripStatus.CONFIRMED)
             )
 
-        repo.save.assert_not_called()
+        repo.update_status.assert_not_called()
 
     def test_transitions_to_in_progress_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.CONFIRMED)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.IN_PROGRESS)
@@ -103,7 +103,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_to_completed_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.IN_PROGRESS)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.COMPLETED)
@@ -113,7 +113,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_to_cancelled_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CANCELLED)
@@ -123,7 +123,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_back_to_planning_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.CANCELLED)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.PLANNING)
@@ -133,7 +133,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_passes_correct_trip_id_to_repository(self):
         trip = make_trip(trip_id=1)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
@@ -144,7 +144,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_passes_correct_owner_id_to_repository(self):
         trip = make_trip(trip_id=1)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)


### PR DESCRIPTION
# Edit trip status
Implements the domain and application layer for editing trip status. Adds the update_status method to the existing UpdateTripUseCase and a new UnauthorizedAccess domain exception.
Changes
src/shared/domain/exceptions.py
- Added UnauthorizedAccess exception class with resource_type, resource_id, and user_id attributes. Will be used in Phase 2 for 403 responses.
src/trips/application/use_cases/update_trip.py
- Added update_status(trip_id, owner_id, new_status) method to UpdateTripUseCase
- Validates trip ownership via find_by_owner() — raises EntityNotFound if trip not found or not owned (prevents information leakage)
- Sets trip.status and trip.updated_at directly (no state machine per PRD requirement)
tests/unit/trips/application/test_update_trip.py (new)
- Successful status transitions to all 5 states (confirmed, in_progress, completed, cancelled, back to planning)
- EntityNotFound raised when trip missing or not owned

---

Add API endpoint for updating trip status with validation of ownership. Extend schemas with a `TripStatusType` for consistent status representation. Introduce `UnauthorizedAccess` exception for improved error handling of unauthorized resource use.

