### PR TITLE
feat: extend trip statuses and implement status update functionality

### DIFF
--- a/auth_service/routes.yml
+++ b/auth_service/routes.yml
@@ -10,3 +10,4 @@ vacation-planner:
   available_routes:
     - /api/trips
     - /api/trips/*
+    - /api/trips/*/*

--- a/fe-client/src/Models.ts
+++ b/fe-client/src/Models.ts
@@ -4,7 +4,7 @@ export interface Trip {
     destination: string;
     startDate: Date;
     endDate: Date;
-    status: 'planning' | 'confirmed' | 'completed';
+    status: 'planning' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
     travelers: Traveler[];
     flights: Flight[];
     accommodations: Accommodation[];

--- a/fe-client/src/components/TripPlansList.jsx
+++ b/fe-client/src/components/TripPlansList.jsx
@@ -31,9 +31,13 @@ const TripPlansList = () => {
             case 'confirmed':
                 return 'bg-green-100 text-green-800 border-green-200';
             case 'planning':
-                return 'bg-yellow-100 text-yellow-800 border-yellow-200';
+                return 'bg-blue-100 text-blue-800 border-blue-200';
+            case 'in_progress':
+                return 'bg-amber-100 text-amber-800 border-amber-200';
             case 'completed':
                 return 'bg-gray-100 text-gray-800 border-gray-200';
+            case 'cancelled':
+                return 'bg-red-100 text-red-800 border-red-200';
             default:
                 return 'bg-gray-100 text-gray-800 border-gray-200';
         }

--- a/fe-client/src/services/TripService.ts
+++ b/fe-client/src/services/TripService.ts
@@ -16,6 +16,8 @@ export interface ITripService {
 
     updateTrip(id: string, updates: Partial<Trip>): Promise<Trip>;
 
+    updateTripStatus(id: string, status: string): Promise<Trip>;
+
     deleteTrip(id: string): Promise<boolean>;
 }
 
@@ -107,6 +109,30 @@ class SimpleTripService implements ITripService {
     }
 
     /**
+     * Update trip status
+     */
+    async updateTripStatus(id: string, status: string): Promise<Trip> {
+        await this.delay(200);
+
+        const index = this.trips.findIndex(t => t.id === id);
+        if (index === -1) {
+            throw new Error(`Trip with id ${id} not found`);
+        }
+
+        // Update status
+        const updatedTrip = {
+            ...this.trips[index],
+            status: status as Trip['status'],
+        };
+
+        this.trips[index] = updatedTrip;
+
+        console.log('✅ Trip status updated:', updatedTrip);
+
+        return updatedTrip;
+    }
+
+    /**
      * Delete trip
      */
     async deleteTrip(id: string): Promise<boolean> {
@@ -188,6 +214,17 @@ class ApiTripService implements ITripService {
             body: JSON.stringify(updates),
         });
         if (!response.ok) throw new Error('Failed to update trip');
+        return response.json();
+    }
+
+    async updateTripStatus(id: string, status: string): Promise<Trip> {
+        const response = await fetch(`${this.baseUrl}/${id}/status`, {
+            method: 'PATCH',
+            credentials: 'include',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ status }),
+        });
+        if (!response.ok) throw new Error('Failed to update trip status');
         return response.json();
     }
 

--- a/fe-client/src/tripDetailsView.tsx
+++ b/fe-client/src/tripDetailsView.tsx
@@ -12,6 +12,7 @@ import TravellersOverview from "./components/TravellersOverview.tsx";
 import { tripService } from "./services/TripService.ts";
 
 type TabKey = 'overview' | 'flights' | 'stays' | 'activities' | 'budget' | 'team';
+type TripStatus = 'planning' | 'confirmed' | 'in_progress' | 'completed' | 'cancelled';
 
 interface Tab {
     key: TabKey;
@@ -23,6 +24,9 @@ const TripDetailsView = () => {
     const { tripId } = useParams();
     const [trip, setTrip] = useState<Trip | null>(null);
     const [activeTab, setActiveTab] = useState<TabKey>('overview');
+    const [originalStatus, setOriginalStatus] = useState<TripStatus | null>(null);
+    const [isUpdating, setIsUpdating] = useState(false);
+    const [error, setError] = useState<string | null>(null);
     const navigate = useNavigate();
 
     // Define tabs
@@ -38,12 +42,36 @@ const TripDetailsView = () => {
     useEffect(() => {
         const timer = setTimeout(async () => {
             if (tripId) {
-                setTrip(await tripService.getTripById(tripId));
+                const fetchedTrip = await tripService.getTripById(tripId);
+                if (fetchedTrip) {
+                    setTrip(fetchedTrip);
+                    setOriginalStatus(fetchedTrip.status);
+                }
             }
         }, 500);
 
         return () => clearTimeout(timer);
     }, [tripId]);
+
+    const handleStatusChange = async (newStatus: TripStatus) => {
+        if (!trip || !tripId) return;
+
+        setIsUpdating(true);
+        setError(null);
+
+        try {
+            const updatedTrip = await tripService.updateTripStatus(tripId, newStatus);
+            setTrip(updatedTrip);
+            setOriginalStatus(updatedTrip.status);
+        } catch (err) {
+            setError('Failed to update status');
+            if (trip) {
+                setTrip({ ...trip, status: originalStatus || trip.status });
+            }
+        } finally {
+            setIsUpdating(false);
+        }
+    };
 
     const renderTabContent = () => {
         if (!trip) return null;
@@ -125,6 +153,28 @@ const TripDetailsView = () => {
                                     className={`inline-block px-3 py-1 rounded-full text-sm font-medium capitalize ${getStatusColor(trip.status)}`}>
                                     {trip.status}
                                 </span>
+                                <select
+                                    value={trip.status}
+                                    onChange={(e) => handleStatusChange(e.target.value as TripStatus)}
+                                    disabled={isUpdating}
+                                    className={`px-3 py-1 rounded-lg text-sm font-medium border ${
+                                        isUpdating
+                                            ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
+                                            : 'bg-white text-gray-700 border-gray-300 cursor-pointer hover:border-gray-400'
+                                    }`}
+                                >
+                                    <option value="planning">Planning</option>
+                                    <option value="confirmed">Confirmed</option>
+                                    <option value="in_progress">In Progress</option>
+                                    <option value="completed">Completed</option>
+                                    <option value="cancelled">Cancelled</option>
+                                </select>
+                                {isUpdating && (
+                                    <span className="text-sm text-gray-500">Updating...</span>
+                                )}
+                                {error && (
+                                    <span className="text-sm text-red-600">{error}</span>
+                                )}
                             </div>
 
                             {/* Location */}

--- a/fe-client/src/tripDetailsView.tsx
+++ b/fe-client/src/tripDetailsView.tsx
@@ -146,21 +146,17 @@ const TripDetailsView = () => {
                 <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 mb-6">
                     <div className="flex flex-col md:flex-row md:justify-between md:items-start gap-4">
                         <div className="flex-1">
-                            {/* Title and Status Badge */}
+                            {/* Title and Status Badge (Clickable Dropdown) */}
                             <div className="flex items-center gap-3 mb-3">
                                 <h1 className="text-3xl font-bold text-gray-900">{trip.name}</h1>
-                                <span
-                                    className={`inline-block px-3 py-1 rounded-full text-sm font-medium capitalize ${getStatusColor(trip.status)}`}>
-                                    {trip.status}
-                                </span>
                                 <select
                                     value={trip.status}
                                     onChange={(e) => handleStatusChange(e.target.value as TripStatus)}
                                     disabled={isUpdating}
-                                    className={`px-3 py-1 rounded-lg text-sm font-medium border ${
+                                    className={`px-3 py-1 rounded-full text-sm font-medium capitalize border-2 ${
                                         isUpdating
-                                            ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed'
-                                            : 'bg-white text-gray-700 border-gray-300 cursor-pointer hover:border-gray-400'
+                                            ? `opacity-50 cursor-not-allowed ${getStatusColor(trip.status)}`
+                                            : `${getStatusColor(trip.status)} cursor-pointer hover:opacity-80`
                                     }`}
                                 >
                                     <option value="planning">Planning</option>
@@ -173,7 +169,7 @@ const TripDetailsView = () => {
                                     <span className="text-sm text-gray-500">Updating...</span>
                                 )}
                                 {error && (
-                                    <span className="text-sm text-red-600">{error}</span>
+                                    <span className="text-sm text-red-600 ml-2">{error}</span>
                                 )}
                             </div>
 

--- a/fe-client/src/utils/StatusColors.ts
+++ b/fe-client/src/utils/StatusColors.ts
@@ -1,8 +1,17 @@
 export const getStatusColor = (status: string): string => {
     const statusLower = status.toLowerCase();
+
+    // Trip status colors
+    if (statusLower === 'planning') return 'bg-blue-100 text-blue-700';
     if (statusLower === 'confirmed') return 'bg-green-100 text-green-700';
+    if (statusLower === 'in_progress') return 'bg-amber-100 text-amber-700';
+    if (statusLower === 'completed') return 'bg-gray-100 text-gray-700';
+    if (statusLower === 'cancelled') return 'bg-red-100 text-red-700';
+
+    // Flight/accommodation/activity status colors
     if (statusLower === 'pending') return 'bg-yellow-100 text-yellow-700';
     if (statusLower === 'booked') return 'bg-blue-100 text-blue-700';
-    if (statusLower === 'cancelled') return 'bg-red-100 text-red-700';
+
+    // Default fallback
     return 'bg-gray-100 text-gray-700';
 };

--- a/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
+++ b/vacation_stay_scrapper/src/trips/application/use_cases/update_trip.py
@@ -1,8 +1,9 @@
+from datetime import date
+
 from ...domain.entities.trip import Trip
 from ...domain.repositories.trip_repository import ITripRepository
 from ...domain.value_objects.trip_status import TripStatus
 from ....shared.domain.exceptions import EntityNotFound
-from datetime import date
 
 
 class UpdateTripUseCase:
@@ -41,8 +42,8 @@ class UpdateTripUseCase:
         Update the status of a trip owned by the authenticated user.
 
         Verifies the trip exists and belongs to the given owner before
-        applying the status update. Both "not found" and "wrong owner" raise
-        EntityNotFound to avoid leaking trip existence to other users.
+        applying the status update. Uses the repository's update_status method
+        to avoid SQLAlchemy identity map conflicts.
 
         Args:
             trip_id: Trip identifier string
@@ -61,7 +62,12 @@ class UpdateTripUseCase:
         if trip is None:
             raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
 
+        updated = await self._repository.update_status(trip_id_int, str(new_status))
+
+        if not updated:
+            raise EntityNotFound(entity_type="Trip", entity_id=trip_id)
+
         trip.status = new_status
         trip.updated_at = date.today()
 
-        return await self._repository.save(trip)
+        return trip

--- a/vacation_stay_scrapper/src/trips/domain/repositories/trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/domain/repositories/trip_repository.py
@@ -87,11 +87,25 @@ class ITripRepository(ABC):
     async def exists(self, trip_id: int) -> bool:
         """
         Check if trip exists
-        
+
         Args:
             trip_id: Trip identifier
-            
+
         Returns:
             True if exists, False otherwise
+        """
+        pass
+
+    @abstractmethod
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        """
+        Update the status of a trip
+
+        Args:
+            trip_id: Trip identifier
+            status: New status value
+
+        Returns:
+            True if updated, False if not found
         """
         pass

--- a/vacation_stay_scrapper/src/trips/infrastructure/persistence/in_memory_trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/infrastructure/persistence/in_memory_trip_repository.py
@@ -112,6 +112,24 @@ class InMemoryTripRepository(ITripRepository):
             True if exists, False otherwise
         """
         return trip_id in self._storage
+
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        """
+        Update the status of a trip
+
+        Args:
+            trip_id: Trip integer identifier
+            status: New status value
+
+        Returns:
+            True if updated, False if not found
+        """
+        trip = self._storage.get(trip_id)
+        if trip is None:
+            return False
+        trip.status = status
+        trip.updated_at = date.today()
+        return True
     
     def count(self) -> int:
         """Get total number of trips"""

--- a/vacation_stay_scrapper/src/trips/infrastructure/persistence/postgres_trip_repository.py
+++ b/vacation_stay_scrapper/src/trips/infrastructure/persistence/postgres_trip_repository.py
@@ -1,7 +1,7 @@
 from datetime import date
 from typing import List, Optional
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.trips.domain.entities.trip import Trip
@@ -87,3 +87,12 @@ class PostgresTripRepository(ITripRepository):
             select(TripOrm.id_).where(TripOrm.id_ == trip_id)
         )
         return result.scalar_one_or_none() is not None
+
+    async def update_status(self, trip_id: int, status: str) -> bool:
+        result = await self._session.execute(
+            update(TripOrm)
+            .where(TripOrm.id_ == trip_id)
+            .values(status=status, updated_at=date.today())
+        )
+        await self._session.flush()
+        return result.rowcount > 0

--- a/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
+++ b/vacation_stay_scrapper/tests/unit/trips/application/test_update_trip.py
@@ -43,7 +43,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_returns_updated_trip_with_new_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
@@ -52,15 +52,15 @@ class TestUpdateTripUseCaseStatus:
         assert result.status == TripStatus.CONFIRMED
         assert result.updated_at is not None
 
-    def test_calls_save_on_repository(self):
+    def test_calls_update_status_on_repository(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
         )
 
-        repo.save.assert_called_once()
+        repo.update_status.assert_called_once()
 
     def test_raises_entity_not_found_when_trip_is_missing(self):
         repo = make_repo(find_by_owner=None)
@@ -81,7 +81,7 @@ class TestUpdateTripUseCaseStatus:
                 UpdateTripUseCase(repo).update_status("42", "different-user", TripStatus.CONFIRMED)
             )
 
-    def test_does_not_call_save_when_trip_does_not_exist(self):
+    def test_does_not_call_update_status_when_trip_does_not_exist(self):
         repo = make_repo(find_by_owner=None)
 
         with pytest.raises(EntityNotFound):
@@ -89,11 +89,11 @@ class TestUpdateTripUseCaseStatus:
                 UpdateTripUseCase(repo).update_status("999", "user-1", TripStatus.CONFIRMED)
             )
 
-        repo.save.assert_not_called()
+        repo.update_status.assert_not_called()
 
     def test_transitions_to_in_progress_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.CONFIRMED)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.IN_PROGRESS)
@@ -103,7 +103,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_to_completed_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.IN_PROGRESS)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.COMPLETED)
@@ -113,7 +113,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_to_cancelled_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.PLANNING)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CANCELLED)
@@ -123,7 +123,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_transitions_back_to_planning_status(self):
         trip = make_trip(trip_id=1, status=TripStatus.CANCELLED)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         result = asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.PLANNING)
@@ -133,7 +133,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_passes_correct_trip_id_to_repository(self):
         trip = make_trip(trip_id=1)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)
@@ -144,7 +144,7 @@ class TestUpdateTripUseCaseStatus:
 
     def test_passes_correct_owner_id_to_repository(self):
         trip = make_trip(trip_id=1)
-        repo = make_repo(find_by_owner=trip, save=trip)
+        repo = make_repo(find_by_owner=trip, update_status=True)
 
         asyncio.run(
             UpdateTripUseCase(repo).update_status("1", "user-1", TripStatus.CONFIRMED)


### PR DESCRIPTION
Add new trip statuses (`in_progress`, `cancelled`) to the domain model and update related utilities, components, and styles. Introduce `updateTripStatus` method to `TripService` for updating trip status both locally and through the API.