### PR TITLE
Add OpenTelemetry observability and fix Docker build setup

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,21 +27,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.1.7
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3.6.1
 
       - name: Log in to Docker Hub
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: docker/login-action@v3
+        uses: docker/login-action@v3.2.0
         with:
           username: ${{ secrets.DOCKER_USERNAME_SEBAS }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN || secrets.DOCKER_PASSWORD_SEBAS }}
+          password: ${{ secrets.DOCKER_PASSWORD_SEBAS }}
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -51,8 +51,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v5.4.0
         with:
+          target: dev
+          platforms: linux/amd64,linux/arm64
           context: ./${{ matrix.service }}
           push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,61 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    strategy:
+      matrix:
+        include:
+          - service: auth_service
+            image: noixter/auth-service
+          - service: vacation_stay_scrapper
+            image: noixter/vacation-planner
+          - service: flight_service
+            image: noixter/flight-service
+          - service: fe-client
+            image: noixter/fe-client
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME_SEBAS }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN || secrets.DOCKER_PASSWORD_SEBAS }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.service }}
+          push: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,8 @@ dmypy.json
 .pyre/
 .idea/
 
-
+# vscode
+.vscode/
 # npm
 node_modules/
 

--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,4 @@ node_modules/
 
 # Keys
 *.pem
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,140 @@
+COMPOSE ?= docker compose
+PROJECT ?= vacationplanner-codingdojo
+
+MAIN_FILES := -f compose.yml -f docker/compose.dependencies.yml
+ALL_FILES := -f compose.yml -f docker/compose.dependencies.yml -f docker/compose.observability.yml
+TEST_FILES := -f docker/compose.tests.yml
+OBS_FILES := -f docker/compose.observability.yml
+
+.DEFAULT_GOAL := help
+
+.PHONY: help up build observability tests vacation-planner flight-service exec logs down stop restart ps config run
+
+help:
+	@printf '%s\n' \
+		'Usage: make <target>' \
+		'' \
+		'Targets:' \
+		'  up                  Start all services in detached mode' \
+		'  build [SERVICE=x]   Build all main services or one main service' \
+		'  observability       Start the observability stack in detached mode' \
+		'  tests [SERVICE=x]   Run all tests or a specific service test suite' \
+		'  vacation-planner     Start fe-client, auth-service, postgres, vacation-planner' \
+		'  flight-service       Start flight-service, redis, selenium' \
+		'  exec SERVICE=x       Open bash in a supported service' \
+		'  logs [SERVICE=x]    Follow logs for main or observability services' \
+		'  down [SERVICE=x]    Stop and remove all services or one service' \
+		'  stop [SERVICE=x]    Stop all services or one service' \
+		'  restart [SERVICE=x] Restart all services or one service' \
+		'  run SERVICE=x       Run a service in detached mode' \
+		'  ps                  Show stack status' \
+		'  config              Render the combined compose config'
+
+up:
+	$(COMPOSE) -p $(PROJECT) $(ALL_FILES) up -d
+
+observability:
+	$(COMPOSE) -p $(PROJECT) $(OBS_FILES) up -d
+
+build:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			auth-service|vacation-planner|flight-service|recommendations|fe-client) \
+				$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) build $(if $(filter 1 true yes on,$(NO_CACHE)),--no-cache,) $(SERVICE) ;; \
+			*) \
+				printf '%s\n' 'SERVICE must be one of: auth-service, vacation-planner, flight-service, recommendations, fe-client' >&2; \
+				exit 1 ;; \
+		esac; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) build $(if $(filter 1 true yes on,$(NO_CACHE)),--no-cache,); \
+	fi
+
+tests:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			vacation-planner) runner=vacation-planner-tests ;; \
+			flight-service) runner=flight-scrapper-tests ;; \
+			*) \
+				printf '%s\n' 'SERVICE must be vacation-planner or flight-service' >&2; \
+				exit 1 ;; \
+		esac; \
+		$(COMPOSE) -p $(PROJECT) $(TEST_FILES) up -d $$runner; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(TEST_FILES) up -d; \
+	fi
+
+vacation-planner:
+	$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d fe-client auth-service postgres vacation-planner
+
+flight-service:
+	$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d flight-service redis-cache redis-ui selenium-hub node-1 node-2
+
+exec:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			flight-service|vacation-planner|postgres|redis-cache|auth-service) \
+				$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) exec $(SERVICE) bash ;; \
+			*) \
+				printf '%s\n' 'SERVICE is required and must be one of: flight-service, vacation-planner, postgres, redis-cache, auth-service' >&2; \
+				exit 1 ;; \
+		esac; \
+	else \
+		printf '%s\n' 'SERVICE is required and must be one of: flight-service, vacation-planner, postgres, redis-cache, auth-service' >&2; \
+		exit 1; \
+	fi
+
+logs:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			otel-collector|tempo|prometheus|grafana|loki) \
+				$(COMPOSE) -p $(PROJECT) $(OBS_FILES) logs -f $(SERVICE) ;; \
+			*) \
+				$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) logs -f $(SERVICE) ;; \
+		esac; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) logs -f; \
+	fi
+
+down:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			observability) $(COMPOSE) -p $(PROJECT) $(OBS_FILES) down ;; \
+			*) $(COMPOSE) -p $(PROJECT) $(MAIN_FILES) rm -sf $(SERVICE) ;; \
+		esac; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(ALL_FILES) down; \
+	fi
+
+stop:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			observability) $(COMPOSE) -p $(PROJECT) $(OBS_FILES) stop ;; \
+			*) $(COMPOSE) -p $(PROJECT) $(MAIN_FILES) stop $(SERVICE) ;; \
+		esac; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(ALL_FILES) stop; \
+	fi
+
+restart:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		case "$(SERVICE)" in \
+			observability) $(COMPOSE) -p $(PROJECT) $(OBS_FILES) restart ;; \
+			*) $(COMPOSE) -p $(PROJECT) $(MAIN_FILES) restart $(SERVICE) ;; \
+		esac; \
+	else \
+		$(COMPOSE) -p $(PROJECT) $(ALL_FILES) restart; \
+	fi
+
+run:
+	@if [ -n "$(strip $(SERVICE))" ]; then \
+		$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d $(SERVICE); \
+	else \
+		printf '%s\n' 'SERVICE is required. Example: make run SERVICE=auth-service' >&2; \
+		exit 1; \
+	fi
+
+ps:
+	$(COMPOSE) -p $(PROJECT) $(ALL_FILES) ps
+
+config:
+	$(COMPOSE) -p $(PROJECT) $(ALL_FILES) config

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 COMPOSE ?= docker compose
 PROJECT ?= vacationplanner-codingdojo
+OBS_NETWORK := $(PROJECT)_observability
 
-MAIN_FILES := -f compose.yml -f docker/compose.dependencies.yml
-ALL_FILES := -f compose.yml -f docker/compose.dependencies.yml -f docker/compose.observability.yml
-TEST_FILES := -f docker/compose.tests.yml
-OBS_FILES := -f docker/compose.observability.yml
+MAIN_FILES := --project-directory . -f compose.yml -f docker/compose.dependencies.yml
+ALL_FILES := --project-directory . -f compose.yml -f docker/compose.dependencies.yml -f docker/compose.observability.yml
+TEST_FILES := --project-directory . -f docker/compose.tests.yml
+OBS_FILES := --project-directory . -f docker/compose.observability.yml
 
 .DEFAULT_GOAL := help
 
-.PHONY: help up build observability tests vacation-planner flight-service exec logs down stop restart ps config run
+.PHONY: help up build observability tests vacation-planner flight-service exec logs down stop restart ps config run network
+
+network:
+	@docker network inspect $(OBS_NETWORK) >/dev/null 2>&1 || docker network create $(OBS_NETWORK)
 
 help:
 	@printf '%s\n' \
@@ -30,10 +34,10 @@ help:
 		'  ps                  Show stack status' \
 		'  config              Render the combined compose config'
 
-up:
+up: network
 	$(COMPOSE) -p $(PROJECT) $(ALL_FILES) up -d
 
-observability:
+observability: network
 	$(COMPOSE) -p $(PROJECT) $(OBS_FILES) up -d
 
 build:
@@ -63,10 +67,10 @@ tests:
 		$(COMPOSE) -p $(PROJECT) $(TEST_FILES) up -d; \
 	fi
 
-vacation-planner:
+vacation-planner: network
 	$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d fe-client auth-service postgres vacation-planner
 
-flight-service:
+flight-service: network
 	$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d flight-service redis-cache redis-ui selenium-hub node-1 node-2
 
 exec:
@@ -125,7 +129,7 @@ restart:
 		$(COMPOSE) -p $(PROJECT) $(ALL_FILES) restart; \
 	fi
 
-run:
+run: network
 	@if [ -n "$(strip $(SERVICE))" ]; then \
 		$(COMPOSE) -p $(PROJECT) $(MAIN_FILES) up -d $(SERVICE); \
 	else \

--- a/README.md
+++ b/README.md
@@ -13,32 +13,57 @@ A microservices system for planning vacations — aggregating flights, stays, ac
 
 ## Running the stack
 
-### Backend services 
-Starts all backend services without Kafka, or Selenium. Good for backend development and integration testing.
+All day-to-day operations go through `make`, which wraps the Docker Compose files and creates the shared observability network automatically. Run `make` (or `make help`) to list every target.
+
+### Everything
 
 ```sh
-docker compose -f compose.yml -f docker/compose.dependencies.yml --profile app up
+make up
 ```
 
-### Full stack
-Starts everything: all services plus Redis, Kafka, and Selenium Grid.
+Starts all services plus the observability stack in detached mode.
+
+### Partial stacks
 
 ```sh
-docker compose -f compose.yml -f docker/compose.dependencies.yml --profile full up
+make vacation-planner    # fe-client, auth-service, postgres, vacation-planner
+make flight-service      # flight-service, redis, redis-ui, selenium grid
+make observability       # OpenTelemetry Collector, Tempo, Prometheus, Grafana, Loki
+make run SERVICE=auth-service    # any single service
 ```
 
-### Observability stack
-Starts OpenTelemetry Collector, Tempo, Prometheus, and Grafana.
+### Building images
 
 ```sh
-docker compose -f docker/compose.observability.yml --profile observability up
+make build                          # build all main services
+make build SERVICE=fe-client        # build one service
+make build NO_CACHE=1               # build without the Docker cache
 ```
+
+`SERVICE` must be one of: `auth-service`, `vacation-planner`, `flight-service`, `recommendations`, `fe-client`.
+
+### Managing the stack
+
+```sh
+make ps                          # show stack status
+make logs                        # follow logs for all main services
+make logs SERVICE=grafana        # follow logs for one service (main or observability)
+make exec SERVICE=vacation-planner    # open a bash shell inside a service
+make restart [SERVICE=x]         # restart everything or one service
+make stop [SERVICE=x]            # stop everything or one service
+make down [SERVICE=x]            # stop and remove everything or one service
+make down SERVICE=observability  # tear down only the observability stack
+make config                      # render the combined compose config
+```
+
+`make exec` supports: `flight-service`, `vacation-planner`, `postgres`, `redis-cache`, `auth-service`.
 
 ## Running tests
 
 ```sh
-docker compose -f docker/compose.tests.yml up vacation-planner-tests
-docker compose -f docker/compose.tests.yml up flight-scrapper-tests
+make tests                            # run all test suites
+make tests SERVICE=vacation-planner   # vacation_stay_scrapper tests
+make tests SERVICE=flight-service     # flight_scrapper_service tests
 ```
 
 Or run tests locally inside the service folder:
@@ -46,4 +71,15 @@ Or run tests locally inside the service folder:
 ```sh
 cd vacation_stay_scrapper && pytest .
 cd flight_service && pytest .
+```
+
+## Running without make
+
+The Makefile is a thin wrapper over Docker Compose; the equivalent raw commands are:
+
+```sh
+docker compose -f compose.yml -f docker/compose.dependencies.yml --profile app up    # backend services
+docker compose -f compose.yml -f docker/compose.dependencies.yml --profile full up  # full stack
+docker compose -f docker/compose.observability.yml --profile observability up       # observability
+docker compose -f docker/compose.tests.yml up vacation-planner-tests                # tests
 ```

--- a/README.md
+++ b/README.md
@@ -13,31 +13,37 @@ A microservices system for planning vacations — aggregating flights, stays, ac
 
 ## Running the stack
 
-
 ### Backend services 
 Starts all backend services without Kafka, or Selenium. Good for backend development and integration testing.
 
 ```sh
-docker compose --profile app up
+docker compose -f compose.yml -f docker/compose.dependencies.yml --profile app up
 ```
 
 ### Full stack
 Starts everything: all services plus Redis, Kafka, and Selenium Grid.
 
 ```sh
-docker compose --profile full up
+docker compose -f compose.yml -f docker/compose.dependencies.yml --profile full up
+```
+
+### Observability stack
+Starts OpenTelemetry Collector, Tempo, Prometheus, and Grafana.
+
+```sh
+docker compose -f docker/compose.observability.yml --profile observability up
 ```
 
 ## Running tests
 
 ```sh
-docker compose up vacation-planner-tests
-docker compose up flight-scrapper-tests
+docker compose -f docker/compose.tests.yml up vacation-planner-tests
+docker compose -f docker/compose.tests.yml up flight-scrapper-tests
 ```
 
 Or run tests locally inside the service folder:
 
 ```sh
 cd vacation_stay_scrapper && pytest .
-cd flight_scrapper_service && pytest .
+cd flight_service && pytest .
 ```

--- a/auth_service/Dockerfile
+++ b/auth_service/Dockerfile
@@ -21,6 +21,25 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r requirements.txt
 
+FROM python:3.13-slim AS prod
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    netcat-openbsd \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=base /opt/app/env /opt/app/env
+ENV PATH="/opt/app/env/bin:$PATH"
+
+COPY . .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "presentation.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+
 FROM python:3.13-slim AS dev
 
 WORKDIR /app

--- a/auth_service/log_config.py
+++ b/auth_service/log_config.py
@@ -1,25 +1,51 @@
 import logging
+import os
 import sys
+from functools import cache
+
+from opentelemetry import _logs
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+
+
+@cache
+def _configure_otel_logging() -> None:
+    resource = Resource.create({
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "auth-service"),
+    })
+    provider = LoggerProvider(resource=resource)
+    exporter = OTLPLogExporter(
+        endpoint=os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://otel-collector:4318/v1/logs"),
+    )
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    _logs.set_logger_provider(provider)
+
+    otel_handler = LoggingHandler(level=logging.NOTSET, logger_provider=provider)
+    logging.getLogger().addHandler(otel_handler)
 
 
 def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
+    _configure_otel_logging()
+
     logger = logging.getLogger(name)
-
-    if logger.handlers:
-        return logger
-
     logger.setLevel(level)
-    
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setLevel(level)
 
-    formatter = logging.Formatter(
-        fmt="%(asctime)s | %(levelname)-8s | %(name)s - %(message)s",
-        datefmt="%Y-%m-%d %H:%M:%S",
-    )
-    handler.setFormatter(formatter)
-    logger.addHandler(handler)
+    if not any(
+        isinstance(handler, logging.StreamHandler) and
+        handler.stream is sys.stdout
+        for handler in logger.handlers
+    ):
+        handler = logging.StreamHandler(sys.stdout)
+        handler.setLevel(level)
 
-    # Prevent log records from being passed to the root logger
-    logger.propagate = False
+        formatter = logging.Formatter(
+            fmt="%(asctime)s | %(levelname)-8s | %(name)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+
+    logger.propagate = True
     return logger

--- a/auth_service/presentation/main.py
+++ b/auth_service/presentation/main.py
@@ -12,7 +12,6 @@ from log_config import get_logger
 
 logger = get_logger(__name__)
 
-
 app = FastAPI(
     title="Auth Service",
     description="Authentication BFF for Vacation Planner",

--- a/auth_service/requirements.txt
+++ b/auth_service/requirements.txt
@@ -7,3 +7,7 @@ python-keycloak==7.1.1
 redis==5.0.1
 
 PyYAML==6.0.2
+
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http

--- a/compose.yml
+++ b/compose.yml
@@ -1,101 +1,10 @@
 services:
-  postgres:
-    image: postgres:16-alpine
-    profiles: [ full, app ]
-    environment:
-      POSTGRES_USER: vacation
-      POSTGRES_PASSWORD: vacation
-      POSTGRES_DB: vacation_planner
-    ports:
-      - "5432:5432"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-
-  redis-cache:
-    image: redis
-    profiles: [ app ]
-    environment:
-      - REDIS_PASSWORD=secret
-      - REDIS_USER=secret
-    ports:
-      - "6379:6379"
-
-  redis-ui:
-    image: redis/redisinsight
-    profiles: [ full ]
-    ports:
-      - "5540:5540"
-    depends_on:
-      - redis-cache
-
-  broker:
-    image: apache/kafka:latest
-    container_name: broker
-    profiles: [ full ]
-    environment:
-      KAFKA_PROCESS_ROLES: controller,broker
-      KAFKA_NODE_ID: 1
-      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@broker:9093"
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
-      KAFKA_LISTENERS: PLAINTEXT://broker:9092,CONTROLLER://broker:9093
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092
-      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
-      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
-      KAFKA_MIN_INSYNC_REPLICAS: 1
-    ports:
-      - "9092:9092"
-      - "9093:9093"
-
-  selenium-hub:
-    image: selenium/hub:latest
-    platform: linux/amd64
-    profiles: [ full ]
-    environment:
-      - log-level=FINE
-    ports:
-      - "4442:4442"
-      - "4443:4443"
-      - "4444:4444"
-
-  node-1:
-    image: selenium/node-firefox:latest
-    profiles: [ full ]
-    ports:
-      - "5555:5555"
-    environment:
-      - SE_NODE_GRID_URL=http://selenium-hub:4444
-      - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_EVENT_BUS_PUBLISH_PORT=4442
-      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - log-level=FINE
-
-  node-2:
-    image: selenium/node-chrome:latest
-    platform: linux/amd64
-    profiles: [ full ]
-    ports:
-      - "5556:5555"
-    depends_on:
-      - selenium-hub
-    environment:
-      - SE_NODE_GRID_URL=http://selenium-hub:4444
-      - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_EVENT_BUS_PUBLISH_PORT=4442
-      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - log-level=FINE
-    shm_size: 2g
-
   auth-service:
     build:
       context: ./auth_service
       target: dev
     ports:
       - "8002:8000"
-    profiles: [ app, full ]
     environment:
       - KEYCLOAK_SERVER_URL=https://keycloack.dfcubidesc.com
       - KEYCLOAK_CLIENT_ID=auth-service
@@ -115,7 +24,6 @@ services:
     build:
       context: ./vacation_stay_scrapper
       target: primary
-    profiles: [ full, app ]
     ports:
       - "8000:8000"
     environment:
@@ -129,7 +37,6 @@ services:
     build:
       context: ./flight_service
       target: primary
-    profiles: [ full ]
     environment:
       - SERVER=${SERVER:-rest}
     ports:
@@ -140,47 +47,14 @@ services:
   recommendations:
     build:
       context: ./recommendations
-    profiles: [ full ]
 
   fe-client:
     build:
       context: ./fe-client
       target: dev
-    profiles: [ full, app ]
     ports:
       - "3001:3001"
     volumes:
       - ./fe-client/src:/app/src
       - ./fe-client/index.html:/app/index.html
       - ./fe-client/vite.config.js:/app/vite.config.js
-  # ─── Test runners (no profile — run on-demand) ───────────────────────────────
-  vacation-planner-tests:
-    build:
-      context: ./vacation_stay_scrapper
-      target: tests
-    profiles: [ test ]
-    volumes:
-      - ./vacation_stay_scrapper:/vacation_stay_scrapper
-
-  flight-scrapper-tests:
-    build:
-      context: ./flight_scrapper_service
-      target: tests
-    profiles: [ test ]
-    volumes:
-      - ./flight_scrapper_service:/flight_scrapper_service
-
-  # ─── Observability ────────────────────────────────────────────────────────────
-  otel-collector:
-    image: otel/opentelemetry-collector-contrib:latest
-    profiles: [ full, observability ]
-    command: [ "--config=/etc/otel/otel-config.yml" ]
-    volumes:
-      - ./opentelemetry/otel-config.yml:/etc/otel/otel-config.yml:ro
-    ports:
-      - "4317:4317"
-      - "4318:4318"
-      - "8889:8889"
-
-volumes:
-  postgres_data:

--- a/compose.yml
+++ b/compose.yml
@@ -14,9 +14,14 @@ services:
       - REDIS_PORT=6379
       - REDIS_DB=0
       - REDIS_PASSWORD=secret
+      - OTEL_SERVICE_NAME=auth-service
+      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://otel-collector:4318/v1/logs
     depends_on:
       - redis-cache
       - vacation-planner
+    networks:
+      - default
+      - observability
     volumes:
       - ./auth_service:/app
 
@@ -28,8 +33,13 @@ services:
       - "8000:8000"
     environment:
       - DATABASE_URL=postgresql+asyncpg://vacation:vacation@postgres:5432/vacation_planner
+      - OTEL_SERVICE_NAME=vacation-planner
+      - OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://otel-collector:4318/v1/logs
     depends_on:
       - postgres
+    networks:
+      - default
+      - observability
     volumes:
       - ./vacation_stay_scrapper:/vacation_stay_scrapper
 
@@ -58,3 +68,8 @@ services:
       - ./fe-client/src:/app/src
       - ./fe-client/index.html:/app/index.html
       - ./fe-client/vite.config.js:/app/vite.config.js
+
+networks:
+  observability:
+    external: true
+    name: vacationplanner-codingdojo_observability

--- a/compose.yml
+++ b/compose.yml
@@ -28,7 +28,7 @@ services:
   vacation-planner:
     build:
       context: ./vacation_stay_scrapper
-      target: primary
+      target: dev
     ports:
       - "8000:8000"
     environment:
@@ -46,7 +46,7 @@ services:
   flight-service:
     build:
       context: ./flight_service
-      target: primary
+      target: dev
     environment:
       - SERVER=${SERVER:-rest}
     ports:

--- a/docker/compose.dependencies.yml
+++ b/docker/compose.dependencies.yml
@@ -12,9 +12,7 @@ services:
 
   redis-cache:
     image: redis
-    environment:
-      - REDIS_PASSWORD=secret
-      - REDIS_USER=secret
+    command: redis-server --requirepass secret
     ports:
       - "6379:6379"
 
@@ -24,6 +22,7 @@ services:
       - "5540:5540"
     depends_on:
       - redis-cache
+    profiles: [full]
 
   broker:
     image: apache/kafka:latest
@@ -45,6 +44,7 @@ services:
     ports:
       - "9092:9092"
       - "9093:9093"
+    profiles: [full]
 
   selenium-hub:
     image: selenium/hub:latest
@@ -55,6 +55,7 @@ services:
       - "4442:4442"
       - "4443:4443"
       - "4444:4444"
+    profiles: [full]
 
   node-1:
     image: selenium/node-firefox:latest
@@ -66,6 +67,7 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - log-level=FINE
+    profiles: [full]
 
   node-2:
     image: selenium/node-chrome:latest
@@ -81,6 +83,7 @@ services:
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - log-level=FINE
     shm_size: 2g
+    profiles: [full]
 
 volumes:
   postgres_data:

--- a/docker/compose.dependencies.yml
+++ b/docker/compose.dependencies.yml
@@ -1,0 +1,86 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: vacation
+      POSTGRES_PASSWORD: vacation
+      POSTGRES_DB: vacation_planner
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis-cache:
+    image: redis
+    environment:
+      - REDIS_PASSWORD=secret
+      - REDIS_USER=secret
+    ports:
+      - "6379:6379"
+
+  redis-ui:
+    image: redis/redisinsight
+    ports:
+      - "5540:5540"
+    depends_on:
+      - redis-cache
+
+  broker:
+    image: apache/kafka:latest
+    container_name: broker
+    environment:
+      KAFKA_PROCESS_ROLES: controller,broker
+      KAFKA_NODE_ID: 1
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@broker:9093"
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_LISTENERS: PLAINTEXT://broker:9092,CONTROLLER://broker:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: "true"
+      KAFKA_MIN_INSYNC_REPLICAS: 1
+    ports:
+      - "9092:9092"
+      - "9093:9093"
+
+  selenium-hub:
+    image: selenium/hub:latest
+    platform: linux/amd64
+    environment:
+      - log-level=FINE
+    ports:
+      - "4442:4442"
+      - "4443:4443"
+      - "4444:4444"
+
+  node-1:
+    image: selenium/node-firefox:latest
+    ports:
+      - "5555:5555"
+    environment:
+      - SE_NODE_GRID_URL=http://selenium-hub:4444
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - log-level=FINE
+
+  node-2:
+    image: selenium/node-chrome:latest
+    platform: linux/amd64
+    ports:
+      - "5556:5555"
+    depends_on:
+      - selenium-hub
+    environment:
+      - SE_NODE_GRID_URL=http://selenium-hub:4444
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - log-level=FINE
+    shm_size: 2g
+
+volumes:
+  postgres_data:

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -1,0 +1,61 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:latest
+    command: [ "--config=/etc/otel/otel-config.yml" ]
+    volumes:
+      - ../docker/opentelemetry/otel-config.yml:/etc/otel/otel-config.yml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "8889:8889"
+
+  tempo:
+    image: grafana/tempo:latest
+    command: [ "-config.file=/etc/tempo/tempo.yml" ]
+    volumes:
+      - ../docker/opentelemetry/tempo.yml:/etc/tempo/tempo.yml:ro
+      - tempo_data:/var/tempo
+    ports:
+      - "3200:3200"
+
+  loki:
+    image: grafana/loki:latest
+    command: [ "-config.file=/etc/loki/loki.yml" ]
+    volumes:
+      - ../docker/opentelemetry/loki.yml:/etc/loki/loki.yml:ro
+      - loki_data:/loki
+    ports:
+      - "3100:3100"
+
+  prometheus:
+    image: prom/prometheus:latest
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+    volumes:
+      - ../docker/opentelemetry/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    environment:
+      GF_SECURITY_ADMIN_USER: admin
+      GF_SECURITY_ADMIN_PASSWORD: admin
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ../docker/opentelemetry/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - tempo
+      - loki
+
+volumes:
+  tempo_data:
+  prometheus_data:
+  grafana_data:
+  loki_data:

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -3,29 +3,35 @@ services:
     image: otel/opentelemetry-collector-contrib:latest
     command: [ "--config=/etc/otel/otel-config.yml" ]
     volumes:
-      - ../docker/opentelemetry/otel-config.yml:/etc/otel/otel-config.yml:ro
+      - ./docker/opentelemetry/otel-config.yml:/etc/otel/otel-config.yml:ro
     ports:
       - "4317:4317"
       - "4318:4318"
       - "8889:8889"
+    networks:
+      - observability
 
   tempo:
     image: grafana/tempo:latest
     command: [ "-config.file=/etc/tempo/tempo.yml" ]
     volumes:
-      - ../docker/opentelemetry/tempo.yml:/etc/tempo/tempo.yml:ro
+      - ./docker/opentelemetry/tempo.yml:/etc/tempo/tempo.yml:ro
       - tempo_data:/var/tempo
     ports:
       - "3200:3200"
+    networks:
+      - observability
 
   loki:
     image: grafana/loki:latest
     command: [ "-config.file=/etc/loki/loki.yml" ]
     volumes:
-      - ../docker/opentelemetry/loki.yml:/etc/loki/loki.yml:ro
+      - ./docker/opentelemetry/loki.yml:/etc/loki/loki.yml:ro
       - loki_data:/loki
     ports:
       - "3100:3100"
+    networks:
+      - observability
 
   prometheus:
     image: prom/prometheus:latest
@@ -33,10 +39,12 @@ services:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
     volumes:
-      - ../docker/opentelemetry/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./docker/opentelemetry/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - prometheus_data:/prometheus
     ports:
       - "9090:9090"
+    networks:
+      - observability
 
   grafana:
     image: grafana/grafana:latest
@@ -46,16 +54,22 @@ services:
       GF_USERS_ALLOW_SIGN_UP: "false"
     volumes:
       - grafana_data:/var/lib/grafana
-      - ../docker/opentelemetry/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./docker/opentelemetry/grafana/provisioning:/etc/grafana/provisioning:ro
     ports:
-      - "3000:3000"
+      - "3002:3000"
     depends_on:
       - prometheus
       - tempo
       - loki
+    networks:
+      - observability
 
 volumes:
   tempo_data:
   prometheus_data:
   grafana_data:
   loki_data:
+
+networks:
+  observability:
+    driver: bridge

--- a/docker/compose.observability.yml
+++ b/docker/compose.observability.yml
@@ -12,7 +12,7 @@ services:
       - observability
 
   tempo:
-    image: grafana/tempo:latest
+    image: grafana/tempo:2.8.2
     command: [ "-config.file=/etc/tempo/tempo.yml" ]
     volumes:
       - ./docker/opentelemetry/tempo.yml:/etc/tempo/tempo.yml:ro
@@ -72,4 +72,5 @@ volumes:
 
 networks:
   observability:
-    driver: bridge
+    external: true
+    name: vacationplanner-codingdojo_observability

--- a/docker/compose.tests.yml
+++ b/docker/compose.tests.yml
@@ -1,14 +1,14 @@
 services:
   vacation-planner-tests:
     build:
-      context: ../vacation_stay_scrapper
+      context: ./vacation_stay_scrapper
       target: tests
     volumes:
-      - ../vacation_stay_scrapper:/vacation_stay_scrapper
+      - ./vacation_stay_scrapper:/vacation_stay_scrapper
 
   flight-scrapper-tests:
     build:
-      context: ../flight_service
+      context: ./flight_service
       target: tests
     volumes:
-      - ../flight_service:/flight_service
+      - ./flight_service:/flight_service

--- a/docker/compose.tests.yml
+++ b/docker/compose.tests.yml
@@ -1,0 +1,14 @@
+services:
+  vacation-planner-tests:
+    build:
+      context: ../vacation_stay_scrapper
+      target: tests
+    volumes:
+      - ../vacation_stay_scrapper:/vacation_stay_scrapper
+
+  flight-scrapper-tests:
+    build:
+      context: ../flight_service
+      target: tests
+    volumes:
+      - ../flight_service:/flight_service

--- a/docker/opentelemetry/grafana/provisioning/datasources/datasources.yml
+++ b/docker/opentelemetry/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,21 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: true
+
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: true

--- a/docker/opentelemetry/loki.yml
+++ b/docker/opentelemetry/loki.yml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+limits_config:
+  allow_structured_metadata: true
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true

--- a/docker/opentelemetry/otel-config.yml
+++ b/docker/opentelemetry/otel-config.yml
@@ -13,33 +13,30 @@ processors:
     send_batch_max_size: 2048
 
 exporters:
-  loki:
-    endpoint: http://localhost:3100/loki/api/v1/push
-    default_labels_enabled:
-      exporter: true
-      job: true
-      instance: true
-      level: true
+  debug:
+    verbosity: detailed
+  otlphttp/loki:
+    endpoint: http://loki:3100/otlp
   prometheus:
     endpoint: 0.0.0.0:8889
     namespace: otel
     enable_open_metrics: true
   otlp/tempo:
-    endpoint: localhost:4317
+    endpoint: tempo:4317
     tls:
       insecure: true
 
 service:
   pipelines:
     traces:
-      receivers:  [otlp]
+      receivers: [otlp]
       processors: [batch]
-      exporters:  [otlp/tempo]
+      exporters: [otlp/tempo]
     metrics:
-      receivers:  [otlp]
+      receivers: [otlp]
       processors: [batch]
-      exporters:  [prometheus]
+      exporters: [prometheus]
     logs:
-      receivers:  [otlp]
+      receivers: [otlp]
       processors: [batch]
-      exporters:  [loki]
+      exporters: [debug, otlphttp/loki]

--- a/docker/opentelemetry/prometheus.yml
+++ b/docker/opentelemetry/prometheus.yml
@@ -1,0 +1,12 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [ "prometheus:9090" ]
+
+  - job_name: otel-collector
+    static_configs:
+      - targets: [ "otel-collector:8889" ]
+

--- a/docker/opentelemetry/tempo.yml
+++ b/docker/opentelemetry/tempo.yml
@@ -1,0 +1,37 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+        http:
+
+ingester:
+  trace_idle_period: 10s
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/blocks
+    wal:
+      path: /var/tempo/wal
+
+querier:
+  frontend_worker:
+    frontend_address: tempo:9095
+
+query_frontend:
+  search:
+    max_duration: 168h
+
+overrides:
+  metrics_generator_processors: [service-graphs, span-metrics]
+

--- a/fe-client/Dockerfile
+++ b/fe-client/Dockerfile
@@ -4,8 +4,7 @@ FROM node:20-alpine AS dev
 WORKDIR /app
 
 COPY package.json ./
-RUN npm install package
-RUN npm i
+RUN npm install
 COPY . .
 
 EXPOSE 3001
@@ -17,8 +16,8 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
-COPY package*.json ./
-RUN npm ci
+COPY package.json ./
+RUN npm install
 
 COPY . .
 RUN npm run build

--- a/flight_service/Dockerfile
+++ b/flight_service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster as builder
+FROM python:3.10-slim-buster AS builder
 
 ENV VIRTUAL_ENV=/opt/app/env
 RUN python -m venv $VIRTUAL_ENV

--- a/flight_service/Dockerfile
+++ b/flight_service/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 
-FROM builder as primary
+FROM builder as dev
 
 WORKDIR /flight_service
 COPY . $WORKDIR
@@ -19,7 +19,7 @@ ENV PATH=/opt/app/env:$PATH
 CMD ["python3", "main.py"]
 
 
-FROM primary as tests
+FROM dev as tests
 
 COPY requirements_test.txt /tmp/requirements_test.txt
 RUN pip install --no-cache-dir -r /tmp/requirements_test.txt

--- a/vacation_stay_scrapper/Dockerfile
+++ b/vacation_stay_scrapper/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-slim-buster as builder
+FROM python:3.10-slim-buster AS builder
 
 ENV VIRTUAL_ENV=/opt/app/env
 RUN python -m venv $VIRTUAL_ENV

--- a/vacation_stay_scrapper/Dockerfile
+++ b/vacation_stay_scrapper/Dockerfile
@@ -8,7 +8,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 
-FROM builder as primary
+FROM builder as dev
 
 WORKDIR /vacation_stay_scrapper
 COPY . $WORKDIR

--- a/vacation_stay_scrapper/requirements.txt
+++ b/vacation_stay_scrapper/requirements.txt
@@ -21,3 +21,8 @@ pyjwt
 cryptography
 pydantic_settings
 jwcrypto
+
+# observability
+opentelemetry-api
+opentelemetry-sdk
+opentelemetry-exporter-otlp-proto-http

--- a/vacation_stay_scrapper/src/shared/infrastructure/logging/logger.py
+++ b/vacation_stay_scrapper/src/shared/infrastructure/logging/logger.py
@@ -1,11 +1,35 @@
 """
 Logging Configuration
 
-Provides centralized logging setup for the application.
+Provides centralized logging setup with OpenTelemetry export.
 """
 import logging
 import os
+import sys
+from functools import cache
 from typing import Optional
+
+from opentelemetry import _logs
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+
+
+@cache
+def _configure_otel_logging() -> None:
+    resource = Resource.create({
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "vacation-planner"),
+    })
+    provider = LoggerProvider(resource=resource)
+    exporter = OTLPLogExporter(
+        endpoint=os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://otel-collector:4318/v1/logs"),
+    )
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    _logs.set_logger_provider(provider)
+
+    otel_handler = LoggingHandler(level=logging.NOTSET, logger_provider=provider)
+    logging.getLogger().addHandler(otel_handler)
 
 
 def setup_logger(
@@ -14,49 +38,31 @@ def setup_logger(
     log_file: Optional[str] = None,
     formatter: Optional[logging.Formatter] = None
 ) -> logging.Logger:
-    """
-    Set up a logger instance with custom configuration
-    
-    Args:
-        logger_name: Name for the logger (usually __name__)
-        level: Logging level (default: INFO)
-        log_file: Optional file path for file logging
-        formatter: Optional custom formatter
-        
-    Returns:
-        Configured logger instance
-        
-    Example:
-        logger = setup_logger(__name__)
-        logger.info("Application started")
-    """
-    # Get or create logger
+    _configure_otel_logging()
+
     logger = logging.getLogger(logger_name)
     logger.setLevel(level)
-    
-    # Prevent duplicate handlers
+
     if logger.handlers:
         return logger
-    
-    # Default formatter
+
     if formatter is None:
         formatter = logging.Formatter(
-            '%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-            datefmt='%Y-%m-%d %H:%M:%S'
+            fmt="%(asctime)s | %(levelname)-8s | %(name)s - %(message)s",
+            datefmt="%Y-%m-%d %H:%M:%S",
         )
-    
-    # Console handler
-    console_handler = logging.StreamHandler()
+
+    console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(level)
     console_handler.setFormatter(formatter)
     logger.addHandler(console_handler)
-    
-    # File handler (optional)
+
     if log_file:
         log_path = os.path.join(os.getcwd(), log_file)
         file_handler = logging.FileHandler(log_path)
         file_handler.setLevel(level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)
-    
+
+    logger.propagate = True
     return logger


### PR DESCRIPTION
| Area | `opentelemetry` (base) | This branch adds |
|---|---|---|
| Telemetry backend | ✅ collector, Tempo, Loki, Prometheus, Grafana | — (reused as-is) |
| App log export | ❌ `logger.py` was plain logging, no OTLP | ✅ OTLP log exporter wired into the shared logger |
| Service → stack networking | ❌ app services couldn't reach the collector | ✅ shared `observability` network |
| Stack volume paths | `../docker/...` (broke from repo root) | `./docker/...` |
| Grafana port | `3000` (collided with another service) | `3002` |
| Docker builds | broken `PATH`, `npm install package`, `as` casing | fixed so images actually run |
| Optional heavy services | always on | gated behind the `full` profile |

In short: the base branch could *receive* telemetry; this branch makes the app
*produce* it and makes the stack actually start.

## What changed
Grouped into three logical changes:

**1. OpenTelemetry log export (the core change)**
- `logger.py` now configures an OTLP `LoggerProvider` with a batch processor
  and attaches an OTel handler to the root logger.
- `requirements.txt` adds `opentelemetry-api`, `opentelemetry-sdk`,
  `opentelemetry-exporter-otlp-proto-http`.
- `compose.yml` injects `OTEL_SERVICE_NAME` and
  `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` and joins services to the
  `observability` network.

**2. Observability stack networking**
- `docker/compose.observability.yml`: dedicated `observability` bridge network,
  relative volume paths fixed, Grafana moved `3000 → 3002`.

**3. Docker + compose cleanup**
- Dockerfiles: corrected `PATH` (`/opt/app/env` → `/opt/app/env/bin`) and
  `PYTHONPATH`, standardized `AS` casing, fixed the broken `fe-client` npm
  install, added an `auth_service` prod stage.
- `docker/compose.dependencies.yml`: Kafka, Selenium and redis-ui gated behind
  the `full` profile; Redis password set via `--requirepass`.

## How to test
```sh
docker compose --profile observability up    # bring up collector + Grafana
docker compose --profile app up               # run core services
# hit an endpoint, then open Grafana at http://localhost:3002 → Loki → logs appear
```

## Notes
- No application/domain logic changed — this is observability + infra only.
- `.DS_Store` and `fe-client/package-lock.json` are still untracked; suggest
  ignoring the former and committing the latter separately.