### PR TITLE
Route auth_service logging through telemetry bootstrap

### DIFF
--- a/auth_service/log_config.py
+++ b/auth_service/log_config.py
@@ -1,34 +1,15 @@
 import logging
-import os
 import sys
-from functools import cache
-
-from opentelemetry import _logs
-from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
-from opentelemetry.sdk.resources import Resource
-
-
-@cache
-def _configure_otel_logging() -> None:
-    resource = Resource.create({
-        "service.name": os.getenv("OTEL_SERVICE_NAME", "auth-service"),
-    })
-    provider = LoggerProvider(resource=resource)
-    exporter = OTLPLogExporter(
-        endpoint=os.getenv("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "http://otel-collector:4318/v1/logs"),
-    )
-    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
-    _logs.set_logger_provider(provider)
-
-    otel_handler = LoggingHandler(level=logging.NOTSET, logger_provider=provider)
-    logging.getLogger().addHandler(otel_handler)
 
 
 def get_logger(name: str, level: int = logging.INFO) -> logging.Logger:
-    _configure_otel_logging()
+    """Return a stdout logger.
 
+    OTLP log export is wired up (only when the collector is reachable) by
+    ``telemetry.setup_telemetry`` via a handler on the root logger. This
+    function only guarantees local stdout logging, which must always work
+    regardless of whether the observability stack is running.
+    """
     logger = logging.getLogger(name)
     logger.setLevel(level)
 

--- a/auth_service/presentation/main.py
+++ b/auth_service/presentation/main.py
@@ -8,6 +8,7 @@ from presentation.auth_router import router as auth_router
 from providers.oidc_provider import OIDCProvider, get_oidc_provider
 from config import internal_routes, get_allowed_hosts
 from log_config import get_logger
+from telemetry import setup_telemetry
 
 
 logger = get_logger(__name__)
@@ -17,6 +18,10 @@ app = FastAPI(
     description="Authentication BFF for Vacation Planner",
     version="1.0.0"
 )
+
+# Centralized telemetry — traces/metrics/logs to the OTel collector when it is
+# reachable; otherwise a single warning and local stdout logging only.
+setup_telemetry("auth-service", app)
 
 app.add_middleware(
     CORSMiddleware,

--- a/auth_service/requirements.txt
+++ b/auth_service/requirements.txt
@@ -11,3 +11,6 @@ PyYAML==6.0.2
 opentelemetry-api
 opentelemetry-sdk
 opentelemetry-exporter-otlp-proto-http
+opentelemetry-instrumentation-fastapi
+opentelemetry-instrumentation-httpx
+opentelemetry-instrumentation-logging


### PR DESCRIPTION
…tstrap

Call setup_telemetry("auth-service", app) at startup in presentation/main.py. Simplify log_config.get_logger to stdout-only and drop the unconditional OTLPLogExporter: OTLP log export is now attached to the root logger by the bootstrap only when the collector is reachable, so local logging always works even when the observability stack is down. Add the instrumentation deps (fastapi/httpx/logging) to requirements.txt.