### PR TITLE
Instrument vacation_stay_scrapper telemetry

### DIFF
--- a/vacation_stay_scrapper/main.py
+++ b/vacation_stay_scrapper/main.py
@@ -18,6 +18,7 @@ from src.shared.infrastructure.logging.logger import setup_logger
 from src.shared.infrastructure.auth.dependencies import get_current_user
 from src.shared.presentation.middleware import setup_middleware
 from src.shared.infrastructure.http.http_connector import HTTPConnector
+from src.shared.infrastructure.telemetry.otel import setup_telemetry
 
 from src.trips.presentation.api.routes import router as trips_router
 
@@ -46,6 +47,11 @@ app = FastAPI(
     version="1.0.0",
     lifespan=lifespan
 )
+
+# Centralized telemetry — traces/metrics/logs to the OTel collector when it is
+# reachable; otherwise a single warning and local stdout logging only. Must run
+# before middleware/routers so instrumentation wraps them.
+setup_telemetry("vacation-planner", app)
 
 # Setup middleware (CORS, logging, exception handling)
 setup_middleware(app)

--- a/vacation_stay_scrapper/requirements.txt
+++ b/vacation_stay_scrapper/requirements.txt
@@ -28,5 +28,6 @@ opentelemetry-exporter-otlp-proto-http
 opentelemetry-instrumentation
 opentelemetry-instrumentation-fastapi
 opentelemetry-instrumentation-httpx
+opentelemetry-instrumentation-requests
 opentelemetry-instrumentation-sqlalchemy
 opentelemetry-instrumentation-logging

--- a/vacation_stay_scrapper/src/shared/infrastructure/telemetry/otel.py
+++ b/vacation_stay_scrapper/src/shared/infrastructure/telemetry/otel.py
@@ -52,7 +52,7 @@ def reset_telemetry_state() -> None:
 def _disabled(service_name: str, endpoint: str, reason: str, *, warn: bool) -> TelemetryStatus:
     global _warned, _status
     if warn and not _warned:
-        logger.warning(f"OpenTelemetry collector unreachable at %{endpoint}; telemetry centralization disabled ({reason}), falling back to local stdout logging." )
+        logger.warning(f"OpenTelemetry collector unreachable at {endpoint}; telemetry centralization disabled ({reason}), falling back to local stdout logging.")
         _warned = True
     _status = TelemetryStatus(enabled=False, service_name=service_name, endpoint=endpoint, reason=reason)
     return _status
@@ -76,7 +76,7 @@ def setup_telemetry(service_name: str, app: object | None = None) -> TelemetrySt
     resolved_name = os.getenv("OTEL_SERVICE_NAME", service_name)
     endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
 
-    if os.getenv("OTEL_SDK_DISABLED"):
+    if _is_truthy(os.getenv("OTEL_SDK_DISABLED")):
         _status = TelemetryStatus(enabled=False, service_name=resolved_name, endpoint=endpoint,
             reason="OTEL_SDK_DISABLED", )
         logger.info("OpenTelemetry disabled via OTEL_SDK_DISABLED; using local logging only.")
@@ -136,3 +136,29 @@ def _configure_sdk(service_name: str, endpoint: str, app: object | None) -> None
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(OTLPLogExporter(endpoint=f"{endpoint}/v1/logs")))
     _logs.set_logger_provider(logger_provider)
     logging.getLogger().addHandler(LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider))
+
+    # Auto-instrumentation. httpx/requests inject W3C traceparent on outbound
+    # calls (cross-service tracing); logging stamps trace_id/span_id into logs;
+    # SQLAlchemy emits DB spans; FastAPI emits server spans + HTTP metrics.
+    from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
+    from opentelemetry.instrumentation.logging import LoggingInstrumentor
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+    LoggingInstrumentor().instrument(set_logging_format=False)
+    RequestsInstrumentor().instrument()
+    HTTPXClientInstrumentor().instrument()
+
+    try:
+        from opentelemetry.instrumentation.sqlalchemy import SQLAlchemyInstrumentor
+
+        from src.shared.infrastructure.database.session import engine
+
+        # Async engines expose the underlying sync engine for instrumentation.
+        SQLAlchemyInstrumentor().instrument(engine=engine.sync_engine)
+    except Exception as exc:  # noqa: BLE001 - DB instrumentation is best-effort
+        logger.warning(f"SQLAlchemy instrumentation skipped: {exc!r}")
+
+    if app is not None:
+        from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+
+        FastAPIInstrumentor.instrument_app(app, tracer_provider=tracer_provider, meter_provider=meter_provider)

--- a/vacation_stay_scrapper/tests/unit/shared/infrastructure/telemetry/test_otel_bootstrap.py
+++ b/vacation_stay_scrapper/tests/unit/shared/infrastructure/telemetry/test_otel_bootstrap.py
@@ -81,6 +81,17 @@ class TestExplicitDisable:
         assert status.enabled is False
         assert status.reason == "OTEL_SDK_DISABLED"
 
+    def test_sdk_disabled_false_string_does_not_disable(self, monkeypatch):
+        # The .env default is the literal string "false"; it must NOT be treated
+        # as "disabled" (base plan §9.6). The probe should run normally.
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+        _force_unreachable(monkeypatch)
+
+        status = otel.setup_telemetry("svc")
+
+        # Not short-circuited by the flag: falls through to the probe instead.
+        assert status.reason == "collector unreachable"
+
 
 class TestConfig:
 


### PR DESCRIPTION
Extend the existing telemetry bootstrap's _configure_sdk with framework auto-instrumentation: FastAPI (server spans + metrics), SQLAlchemy via the async engine's sync_engine (DB spans, best-effort), requests + httpx (client spans + W3C traceparent), and logging. Call setup_telemetry("vacation-planner", app) at startup before middleware. Fix the OTEL_SDK_DISABLED check to compare truthy values (so the .env default "false" no longer disables) and drop a stray "%" in the fallback warning. Add opentelemetry-instrumentation-requests and a regression test for the truthy fix.