### PR TITLE
bootstrap telemetry in flight_service startup

### DIFF
--- a/flight_service/main.py
+++ b/flight_service/main.py
@@ -6,6 +6,7 @@ from enum import Enum
 from typing import Callable, Union
 
 from bootstrap import bootstrap
+from telemetry import setup_telemetry
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('flight_scrapper')
@@ -18,6 +19,11 @@ class ServerTypes(Enum):
 
 
 dependencies = bootstrap()
+
+# Centralized telemetry — traces/metrics/logs to the OTel collector when it is
+# reachable; otherwise a single warning and local stdout logging only. Runs
+# before app_factory() so whichever SERVER type starts inherits the setup.
+setup_telemetry("flight-service")
 
 
 def app_factory(method: str) -> Union[Callable | bool]:

--- a/flight_service/requirements.txt
+++ b/flight_service/requirements.txt
@@ -64,3 +64,15 @@ faker
 
 #openfeature
 openfeature-sdk==0.8.1
+
+# observability (OpenTelemetry) — services degrade gracefully if the collector is unreachable.
+# Pinned to a consistent 1.24.0 / 0.45b0 set. Unpinned, pip backtracks the OTLP exporter to
+# 1.15.0 (incompatible with a newer sdk → ImportError: LogData). The newest OTel (1.44.0) can't
+# be used here because opentelemetry-proto>=1.44 needs protobuf>=5, conflicting with this
+# service's pinned grpcio-tools==1.62.1 (protobuf<5). 1.24.0's proto allows protobuf<5.
+opentelemetry-sdk==1.24.0
+opentelemetry-exporter-otlp-proto-http==1.24.0
+opentelemetry-instrumentation==0.45b0
+opentelemetry-instrumentation-flask==0.45b0
+opentelemetry-instrumentation-requests==0.45b0
+opentelemetry-instrumentation-logging==0.45b0


### PR DESCRIPTION
Call setup_telemetry("flight-service") in main.py after bootstrap() and before app_factory(), so whichever SERVER type starts inherits the providers and instrumentation. Add the OTel deps to requirements.txt, pinned to the 1.24.0 / 0.45b0 set: unpinned, pip backtracks the OTLP exporter to 1.15.0 (ImportError: LogData); 1.44.0 can't be used because opentelemetry-proto>=1.44 needs protobuf>=5, conflicting with this service's grpcio-tools==1.62.1 (protobuf<5).