### PR TITLE
flight_service telemetry disable + config tests

### DIFF
--- a/flight_service/tests/unit/test_telemetry_bootstrap.py
+++ b/flight_service/tests/unit/test_telemetry_bootstrap.py
@@ -57,3 +57,59 @@ class TestGracefulFallback:
     def test_setup_never_raises_when_probe_fails(self, monkeypatch):
         _force_unreachable(monkeypatch)
         assert telemetry.setup_telemetry("flight-service").enabled is False
+
+
+class TestExplicitDisable:
+
+    def test_sdk_disabled_flag_skips_probe_and_stays_disabled(self, monkeypatch):
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+
+        def _boom(*_a, **_k):
+            raise AssertionError("probe should not run when OTEL_SDK_DISABLED is set")
+
+        monkeypatch.setattr(telemetry, "_probe_collector", _boom)
+
+        status = telemetry.setup_telemetry("flight-service")
+
+        assert status.enabled is False
+        assert status.reason == "OTEL_SDK_DISABLED"
+
+    def test_sdk_disabled_false_string_does_not_disable(self, monkeypatch):
+        # The .env default is the literal string "false"; it must NOT disable.
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+        _force_unreachable(monkeypatch)
+
+        status = telemetry.setup_telemetry("flight-service")
+
+        assert status.reason == "collector unreachable"
+
+
+class TestConfig:
+
+    def test_service_name_env_overrides_argument(self, monkeypatch):
+        _force_unreachable(monkeypatch)
+        monkeypatch.setenv("OTEL_SERVICE_NAME", "override-name")
+
+        status = telemetry.setup_telemetry("passed-name")
+
+        assert status.service_name == "override-name"
+
+    def test_endpoint_host_port_parsing(self):
+        assert telemetry._endpoint_host_port("http://otel-collector:4318") == ("otel-collector", 4318)
+
+    def test_endpoint_host_port_defaults_port(self):
+        host, port = telemetry._endpoint_host_port("http://collector")
+        assert (host, port) == ("collector", telemetry.DEFAULT_OTLP_HTTP_PORT)
+
+    def test_sdk_failure_downgrades_to_disabled(self, monkeypatch):
+        monkeypatch.setattr(telemetry, "_probe_collector", lambda host, port, timeout=0.5: True)
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("no otel installed")
+
+        monkeypatch.setattr(telemetry, "_configure_sdk", _boom)
+
+        status = telemetry.setup_telemetry("flight-service")
+
+        assert status.enabled is False
+        assert status.reason.startswith("SDK setup failed")


### PR DESCRIPTION
Add TestExplicitDisable (OTEL_SDK_DISABLED short-circuits before the probe; the literal "false" does not disable) and TestConfig (service-name env override, endpoint parsing, SDK-failure downgrade). Completes the bootstrap test suite.