### PR TITLE
Send date-only strings when creating a trip

### DIFF
--- a/fe-client/src/components/NewTripWizard.tsx
+++ b/fe-client/src/components/NewTripWizard.tsx
@@ -108,8 +108,13 @@ const NewTripWizard = () => {
         }
 
         try {
+            // Backend `date` fields reject full ISO datetime strings, so serialize
+            // date-only values as YYYY-MM-DD before sending.
+            const toDateString = (d: string | Date | undefined): string =>
+                (d ? new Date(d) : new Date()).toISOString().split('T')[0];
+
             // Parse budget value
-            const totalBudget = formData.budget.totalBudget 
+            const totalBudget = formData.budget.totalBudget
                 ? parseFloat(formData.budget.totalBudget) 
                 : 0;
             
@@ -159,12 +164,8 @@ const NewTripWizard = () => {
                     name: formData.stays.name || '',
                     type: (formData.stays.type || 'hotel') as 'hotel' | 'airbnb' | 'hostel' | 'resort',
                     image: '',
-                    checkIn: formData.stays.checkIn 
-                        ? new Date(formData.stays.checkIn) 
-                        : new Date(),
-                    checkOut: formData.stays.checkOut 
-                        ? new Date(formData.stays.checkOut) 
-                        : new Date(),
+                    checkIn: toDateString(formData.stays.checkIn),
+                    checkOut: toDateString(formData.stays.checkOut),
                     pricePerNight: pricePerNight,
                     totalPrice: totalPrice,
                     rating: 0,
@@ -183,9 +184,7 @@ const NewTripWizard = () => {
                 activities.push({
                     id: `activity_${Date.now()}`,
                     name: formData.activities.name || '',
-                    date: formData.activities.date 
-                        ? new Date(formData.activities.date) 
-                        : new Date(),
+                    date: toDateString(formData.activities.date),
                     cost: activityCost,
                     status: 'pending' as const,
                     category: formData.activities.category || '',
@@ -215,12 +214,8 @@ const NewTripWizard = () => {
             const tripData = {
                 name: formData.overview.name || 'Untitled Trip',
                 destination: formData.overview.destination || 'TBD',
-                startDate: formData.overview.startDate 
-                    ? new Date(formData.overview.startDate) 
-                    : new Date(),
-                endDate: formData.overview.endDate 
-                    ? new Date(formData.overview.endDate) 
-                    : new Date(),
+                startDate: toDateString(formData.overview.startDate),
+                endDate: toDateString(formData.overview.endDate),
                 status: 'planning' as const,
                 travelers: travelers,
                 flights: flights,

--- a/fe-client/src/components/NewTripWizard.tsx
+++ b/fe-client/src/components/NewTripWizard.tsx
@@ -6,6 +6,7 @@ import { useAuth } from '../hooks/useAuth';
 // Import step components
 import OverviewStep from './wizard-steps/OverviewStep';
 import FlightsStep from './wizard-steps/FlightsStep';
+import { isValidIata } from './wizard-steps/FlightForm';
 import StaysStep from './wizard-steps/StaysStep';
 import ActivitiesStep from './wizard-steps/ActivitiesStep';
 import BudgetStep from './wizard-steps/BudgetStep';
@@ -104,6 +105,19 @@ const NewTripWizard = () => {
         if (!isAuthenticated) {
             alert('You must be logged in to create a trip.');
             navigate('/');
+            return;
+        }
+
+        // Guard: any flight being submitted must carry valid 3-letter IATA
+        // airport codes, otherwise the backend rejects the request (max_length=3).
+        const flightsToSubmit = formData.flights.filter(f => f.airline || f.flightNumber);
+        const hasInvalidAirport = flightsToSubmit.some(
+            f => !isValidIata(f.departureAirport) || !isValidIata(f.arrivalAirport)
+        );
+        if (hasInvalidAirport) {
+            alert('Please enter a valid 3-letter airport code (e.g., JFK) for each flight.');
+            const flightsStep = steps.findIndex(s => s.id === 'flights');
+            if (flightsStep >= 0) setCurrentStep(flightsStep);
             return;
         }
 

--- a/fe-client/src/components/wizard-steps/FlightForm.tsx
+++ b/fe-client/src/components/wizard-steps/FlightForm.tsx
@@ -9,7 +9,20 @@ interface FlightFormProps {
     canRemove: boolean;
 }
 
+// IATA airport codes are exactly three letters (e.g. JFK, BOG, CDG).
+const IATA_PATTERN = /^[A-Z]{3}$/;
+
+// Keep only letters, uppercase, and cap at 3 chars so the field can never
+// hold a value the backend will reject (max_length=3).
+const toIataCode = (value: string): string =>
+    value.toUpperCase().replace(/[^A-Z]/g, '').slice(0, 3);
+
+export const isValidIata = (value: string): boolean => IATA_PATTERN.test(value);
+
 const FlightForm: React.FC<FlightFormProps> = ({ flight, index, onChange, onRemove, canRemove }) => {
+    const departureInvalid = flight.departureAirport.length > 0 && !isValidIata(flight.departureAirport);
+    const arrivalInvalid = flight.arrivalAirport.length > 0 && !isValidIata(flight.arrivalAirport);
+
     return (
         <div className="border border-gray-200 rounded-xl p-5 space-y-4">
             {/* Header */}
@@ -60,15 +73,24 @@ const FlightForm: React.FC<FlightFormProps> = ({ flight, index, onChange, onRemo
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
-                            Airport
+                            Airport (IATA code)
                         </label>
                         <input
                             type="text"
                             value={flight.departureAirport}
-                            onChange={(e) => onChange(index, 'departureAirport', e.target.value)}
-                            placeholder="e.g., JFK or New York"
-                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                            onChange={(e) => onChange(index, 'departureAirport', toIataCode(e.target.value))}
+                            placeholder="e.g., JFK"
+                            maxLength={3}
+                            aria-invalid={departureInvalid}
+                            className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:border-transparent bg-white uppercase ${
+                                departureInvalid
+                                    ? 'border-red-400 focus:ring-red-500'
+                                    : 'border-gray-300 focus:ring-blue-500'
+                            }`}
                         />
+                        {departureInvalid && (
+                            <p className="mt-1 text-xs text-red-600">Enter the 3-letter airport code (e.g., JFK).</p>
+                        )}
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -90,15 +112,24 @@ const FlightForm: React.FC<FlightFormProps> = ({ flight, index, onChange, onRemo
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">
-                            Airport
+                            Airport (IATA code)
                         </label>
                         <input
                             type="text"
                             value={flight.arrivalAirport}
-                            onChange={(e) => onChange(index, 'arrivalAirport', e.target.value)}
-                            placeholder="e.g., LAX or Los Angeles"
-                            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+                            onChange={(e) => onChange(index, 'arrivalAirport', toIataCode(e.target.value))}
+                            placeholder="e.g., LAX"
+                            maxLength={3}
+                            aria-invalid={arrivalInvalid}
+                            className={`w-full px-4 py-2 border rounded-lg focus:ring-2 focus:border-transparent bg-white uppercase ${
+                                arrivalInvalid
+                                    ? 'border-red-400 focus:ring-red-500'
+                                    : 'border-gray-300 focus:ring-blue-500'
+                            }`}
                         />
+                        {arrivalInvalid && (
+                            <p className="mt-1 text-xs text-red-600">Enter the 3-letter airport code (e.g., LAX).</p>
+                        )}
                     </div>
                     <div>
                         <label className="block text-sm font-medium text-gray-700 mb-2">


### PR DESCRIPTION
Trip date fields were serialized as full ISO datetime strings via JS Date objects, which the backend `date` schema rejects with 422. Serialize startDate/endDate/checkIn/checkOut/activity date as YYYY-MM-DD instead.